### PR TITLE
feat(prime): Add sync mode and fix data propagation for PRIME training

### DIFF
--- a/prime/config/prime_trainer.yaml
+++ b/prime/config/prime_trainer.yaml
@@ -21,6 +21,7 @@ actor_rollout_ref:
   model:
     use_remove_padding: True
   rollout:
+    mode: sync
     # number of responses (i.e. num sample times)
     n: 4
   actor:

--- a/prime/prime_dp_rm.py
+++ b/prime/prime_dp_rm.py
@@ -86,7 +86,7 @@ class DataParallelPRIMERewardModel:
                 attention_mask=None,
                 position_ids=position_ids_rmpad,
                 use_cache=False,
-                return_dict=self.use_fused_kernels,
+                return_dict=True,
             )
 
             if self.use_fused_kernels:
@@ -114,7 +114,7 @@ class DataParallelPRIMERewardModel:
                 attention_mask=micro_batch["attention_mask"],
                 position_ids=micro_batch["position_ids"],
                 use_cache=False,
-                return_dict=self.use_fused_kernels,
+                return_dict=True,
             )
 
             if self.use_fused_kernels:
@@ -139,6 +139,7 @@ class DataParallelPRIMERewardModel:
                         attention_mask=None,
                         position_ids=position_ids_rmpad,
                         use_cache=False,
+                        return_dict=True,
                     )
 
                     if self.use_fused_kernels:
@@ -163,6 +164,7 @@ class DataParallelPRIMERewardModel:
                         attention_mask=micro_batch["attention_mask"],
                         position_ids=micro_batch["position_ids"],
                         use_cache=False,
+                        return_dict=True,
                     )
 
                     if self.use_fused_kernels:

--- a/prime/prime_ray_trainer.py
+++ b/prime/prime_ray_trainer.py
@@ -51,6 +51,7 @@ def compute_advantage(data: DataProto, adv_estimator, config):
         )
         data.batch["advantages"] = advantages
         data.batch["returns"] = returns
+        data.batch["response_mask"] = response_mask
     else:
         raise NotImplementedError
     return data


### PR DESCRIPTION
## Summary

This PR fixes critical issues that prevent PRIME from training correctly on modern infrastructure.

## Problem

PRIME recipe fails to train properly due to:
1. Missing sync mode configuration (causes silent reward corruption)
2. Missing `response_mask` in data batch (causes `KeyError`)
3. Inconsistent `return_dict` behavior (causes `AttributeError`)

## Changes

### 1. Sync Mode (`prime_trainer.yaml`)
```yaml
rollout:
  mode: sync  # Added
```

**Why**: PRIME's RLOO advantage computation requires all generations from the same policy checkpoint. The default async mode mixes generations from different checkpoints, corrupting the reward signal silently.

### 2. Response Mask (`prime_ray_trainer.py`)
```python
data.batch["response_mask"] = response_mask  # Added
```

**Why**: `compute_advantage()` computes `response_mask` but doesn't store it. Downstream reward computation expects this, causing `KeyError`.

### 3. return_dict Fix (`prime_dp_rm.py`)
```python
return_dict=True  # Changed from self.use_fused_kernels
```

**Why**: When `use_fused_kernels=False`, model returns tuple instead of dict, causing `AttributeError`.

## Testing

- **Hardware**: NVIDIA B200 GPUs (2 nodes, 8 GPUs each)
- **Model**: Qwen 2.5 32B (dense)
- **Python**: 3.10+
- **Result**: Training converges successfully

Tested and validated by Lynx team.