### PR TITLE
Prime multinode stability

### DIFF
--- a/prime/config/prime_trainer.yaml
+++ b/prime/config/prime_trainer.yaml
@@ -21,6 +21,7 @@ actor_rollout_ref:
   model:
     use_remove_padding: True
   rollout:
+    mode: sync
     # number of responses (i.e. num sample times)
     n: 4
   actor:

--- a/prime/prime_dp_rm.py
+++ b/prime/prime_dp_rm.py
@@ -86,7 +86,7 @@ class DataParallelPRIMERewardModel:
                 attention_mask=None,
                 position_ids=position_ids_rmpad,
                 use_cache=False,
-                return_dict=self.use_fused_kernels,
+                return_dict=True,
             )
 
             if self.use_fused_kernels:
@@ -114,7 +114,7 @@ class DataParallelPRIMERewardModel:
                 attention_mask=micro_batch["attention_mask"],
                 position_ids=micro_batch["position_ids"],
                 use_cache=False,
-                return_dict=self.use_fused_kernels,
+                return_dict=True,
             )
 
             if self.use_fused_kernels:
@@ -139,6 +139,7 @@ class DataParallelPRIMERewardModel:
                         attention_mask=None,
                         position_ids=position_ids_rmpad,
                         use_cache=False,
+                        return_dict=True,
                     )
 
                     if self.use_fused_kernels:
@@ -163,6 +164,7 @@ class DataParallelPRIMERewardModel:
                         attention_mask=micro_batch["attention_mask"],
                         position_ids=micro_batch["position_ids"],
                         use_cache=False,
+                        return_dict=True,
                     )
 
                     if self.use_fused_kernels:

--- a/prime/prime_fsdp_workers.py
+++ b/prime/prime_fsdp_workers.py
@@ -276,6 +276,7 @@ class PRIMERewardModelWorker(Worker):
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.reward_module)
             load_fsdp_model_to_gpu(self.ref_module)
+            torch.distributed.barrier()
         micro_batch_size = self.config.micro_batch_size_per_gpu
         data.meta_info["micro_batch_size"] = micro_batch_size
         data.meta_info["max_token_len"] = self.config.forward_max_token_len_per_gpu
@@ -302,6 +303,8 @@ class PRIMERewardModelWorker(Worker):
         if self._is_offload_param:
             offload_fsdp_model_to_cpu(self.reward_module)
             offload_fsdp_model_to_cpu(self.ref_module)
+            torch.distributed.barrier()
+            torch.cuda.empty_cache()
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
@@ -310,6 +313,7 @@ class PRIMERewardModelWorker(Worker):
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.ref_module)
             load_fsdp_model_to_gpu(self.reward_module)
+            torch.distributed.barrier()
         if self._is_offload_optimizer:
             load_fsdp_optimizer(optimizer=self.reward_optimizer, device_id=get_device_id())
 
@@ -341,6 +345,8 @@ class PRIMERewardModelWorker(Worker):
         if self._is_offload_param:
             offload_fsdp_model_to_cpu(self.reward_module)
             offload_fsdp_model_to_cpu(self.ref_module)
+            torch.distributed.barrier()
+            torch.cuda.empty_cache() 
         if self._is_offload_optimizer:
             offload_fsdp_optimizer(optimizer=self.reward_optimizer)
         output = output.to("cpu")

--- a/prime/prime_fsdp_workers.py
+++ b/prime/prime_fsdp_workers.py
@@ -346,7 +346,7 @@ class PRIMERewardModelWorker(Worker):
             offload_fsdp_model_to_cpu(self.reward_module)
             offload_fsdp_model_to_cpu(self.ref_module)
             torch.distributed.barrier()
-            torch.cuda.empty_cache() 
+            torch.cuda.empty_cache()
         if self._is_offload_optimizer:
             offload_fsdp_optimizer(optimizer=self.reward_optimizer)
         output = output.to("cpu")

--- a/prime/prime_ray_trainer.py
+++ b/prime/prime_ray_trainer.py
@@ -51,6 +51,7 @@ def compute_advantage(data: DataProto, adv_estimator, config):
         )
         data.batch["advantages"] = advantages
         data.batch["returns"] = returns
+        data.batch["response_mask"] = response_mask
     else:
         raise NotImplementedError
     return data

--- a/prime/prime_ray_trainer.py
+++ b/prime/prime_ray_trainer.py
@@ -276,8 +276,10 @@ class RayPRIMETrainer(RayPPOTrainer):
         local_latest_checkpointed_iteration = os.path.join(
             self.config.trainer.default_local_dir, "latest_checkpointed_iteration.txt"
         )
-        with open(local_latest_checkpointed_iteration, "w") as f:
+        temp_tracker = local_latest_checkpointed_iteration + ".tmp"
+        with open(temp_tracker, "w") as f:
             f.write(str(self.global_steps))
+        os.replace(temp_tracker, local_latest_checkpointed_iteration)
 
     def _load_checkpoint(self):
         if self.config.trainer.resume_mode == "disable":


### PR DESCRIPTION
## Summary

Add stability improvements for multi-node PRIME training with parameter offloading.

## Changes

### 1. Atomic Checkpoint Tracker (`prime_ray_trainer.py`)
```python
# Before (not atomic - can corrupt on crash)
with open(tracker_file, "w") as f:
    f.write(str(self.global_steps))

# After (atomic write)
temp_tracker = tracker_file + ".tmp"
with open(temp_tracker, "w") as f:
    f.write(str(self.global_steps))
os.replace(temp_tracker, tracker_file)
```

**Why**: If training crashes during write, the tracker file could be empty or corrupted. Atomic write ensures the file is either fully written or unchanged.

### 2. Distributed Barriers (`prime_fsdp_workers.py`)
```python
if self._is_offload_param:
    load_fsdp_model_to_gpu(self.reward_module)
    load_fsdp_model_to_gpu(self.ref_module)
    torch.distributed.barrier()  # Sync all workers
```

**Why**: PRIME requires synchronous rollout mode (`mode: sync`) for correct RLOO advantage computation. In multi-node setups with param offloading, workers may complete load/offload at different times due to network latency. Barriers ensure all workers are synchronized before proceeding, preventing race conditions and potential NCCL hangs.

**Note**: These barriers are safe because PRIME always runs in sync mode.

### 3. CUDA Cache Clearing (`prime_fsdp_workers.py`)
```python
if self._is_offload_param:
    offload_fsdp_model_to_cpu(self.reward_module)
    offload_fsdp_model_to_cpu(self.ref_module)
    torch.distributed.barrier()
    torch.cuda.empty_cache()
```

**Why**: After offloading models to CPU, clearing the CUDA cache returns memory to the allocator pool, reducing memory fragmentation for large models.
