### PR TITLE
[feat] Atropos GRPO recipe implementation (Issue #1782)

### DIFF
--- a/atropos/grpo_atropos_trainer.py
+++ b/atropos/grpo_atropos_trainer.py
@@ -96,8 +96,16 @@ class RayGRPOAtroposTrainer(RayPPOTrainer):
 
     def _register_with_atropos(self) -> None:
         trainer_cfg = getattr(self.config, "trainer", None)
-        project_name = getattr(trainer_cfg, "project_name", "verl_atropos") if trainer_cfg is not None else "verl_atropos"
-        experiment_name = getattr(trainer_cfg, "experiment_name", "grpo") if trainer_cfg is not None else "grpo"
+        project_name = (
+            getattr(trainer_cfg, "project_name", "verl_atropos")
+            if trainer_cfg is not None
+            else "verl_atropos"
+        )
+        experiment_name = (
+            getattr(trainer_cfg, "experiment_name", "grpo")
+            if trainer_cfg is not None
+            else "grpo"
+        )
 
         rollout_n = int(self.config.actor_rollout_ref.rollout.n)
         batch_size = int(self.config.data.train_batch_size) * max(1, rollout_n)
@@ -108,7 +116,11 @@ class RayGRPOAtroposTrainer(RayPPOTrainer):
             "wandb_project": experiment_name,
             "batch_size": batch_size,
             "max_token_len": max_token_len,
-            "checkpoint_dir": getattr(trainer_cfg, "default_local_dir", "./checkpoints") if trainer_cfg else "./checkpoints",
+            "checkpoint_dir": (
+                getattr(trainer_cfg, "default_local_dir", "./checkpoints")
+                if trainer_cfg
+                else "./checkpoints"
+            ),
             "save_checkpoint_interval": getattr(trainer_cfg, "save_freq", 0) if trainer_cfg else 0,
             "starting_step": 0,
             "num_steps": int(getattr(trainer_cfg, "total_training_steps", 0) or 0),


### PR DESCRIPTION
Recipe-side implementation for the Atropos-VERL GRPO integration addressing issue volcengine/verl#1782.

**What's in this PR:**

- Complete GRPO training recipe with Atropos environments API
- Token-level advantage override support when provided by environments
- Service orchestration launcher (Atropos API + vLLM + training)
- Working GSM8K example with demonstrated improvements

**Key Files:**

- `atropos/atropos_integration.py` - Atropos API client and advantage handling
- `atropos/grpo_atropos_trainer.py` - RayGRPOAtroposTrainer implementation
- `atropos/launch_atropos_verl_services.py` - Unified service launcher
- `atropos/config/atropos_grpo_small.yaml` - Reference configuration
- `atropos/tests/` - Integration tests

### Usage:

```bash
python atropos/launch_atropos_verl_services.py \
  --config atropos/config/atropos_grpo_small.yaml
```

Tested with `atropos_grpo_small.yaml` on GSM8K (A100, 372 steps):

<img width="1320" height="960" alt="qwen2 5_3b_grpo_atropos_verl_small" src="https://github.com/user-attachments/assets/9d5eab2d-8a0f-4172-aca5-3522a9943dd1" />


- Steady reward and accuracy improvements
- Bounded stability metrics (KL, entropy, grad norm)
- W&B: https://wandb.ai/vyomakesh018-prime-intellect/verl_grpo_example_gsm8k/runs/bp9qk39x

Part of parent PR: [volcengine/verl](https://github.com/volcengine/verl/pull/5017) (#5017)
