### PR TITLE
feat(qat): Align QAT Megatron recipe with engine_workers config schema

### DIFF
--- a/qat/config/dapo_qat_megatron_trainer.yaml
+++ b/qat/config/dapo_qat_megatron_trainer.yaml
@@ -1,7 +1,15 @@
-# DAPO trainer config with QAT (Quantization-Aware Training) support
+# DAPO trainer config with QAT (Quantization-Aware Training) support for Megatron backend
+# This config extends ppo_megatron_trainer.yaml with QAT-specific settings
 #
 # QAT Modes:
 #   - w4a16: Weight-only 4-bit quantization (NVFP4)
+#
+# Usage:
+#   python -m recipe.dapo.main_dapo \
+#     --config-path recipe/qat/config \
+#     --config-name dapo_qat_megatron_trainer \
+#     actor_rollout_ref.actor.megatron.qat.mode=w4a16 \
+#     actor_rollout_ref.actor.megatron.qat.quantization_config_path=recipe/qat/config/nvfp4_w4a16_megatron.json
 
 hydra:
   searchpath:
@@ -14,13 +22,16 @@ defaults:
 data:
   gen_batch_size: ${data.train_batch_size}
 
-reward_model:
-  reward_manager: dapo
-  overlong_buffer: 
-    enable: false
-    len: 0
-    penalty_factor: 0.0
-    log: false
+reward:
+  reward_manager:
+    name: dapo
+  reward_kwargs:
+    overlong_buffer_cfg:
+      enable: false
+      len: 0
+      penalty_factor: 0.0
+      log: false
+    max_resp_len: null
 
 algorithm:
   filter_groups:
@@ -32,19 +43,25 @@ algorithm:
 trainer:
   project_name: verl-dapo-qat
 
+# ============================================================
+# QAT Configuration (overrides defaults in engine/megatron.yaml)
+# ============================================================
 actor_rollout_ref:
   actor:
-    qat:
-      # Enable QAT
-      enable: true
-      # Quantization mode: "w4a16" (weight-only)
-      mode: "w4a16"
-      group_size: 16
-      # Layers to skip (not quantized)
-      # Megatron use fnmatch patterns to match layer names
-      ignore_patterns:
-        - "lm_head"
-        - "*mlp.gate"
-
-      activation_observer: null
-      quantization_config_path: null
+    megatron:
+      qat:
+        # Enable QAT
+        enable: true
+        # Quantization mode: "w4a16" (weight-only)
+        mode: "w4a16"
+        # Quantization group size (NVFP4 requires 16)
+        group_size: 16
+        # Layers to skip (not quantized)
+        # Megatron uses fnmatch patterns to match layer names
+        ignore_patterns:
+          - "lm_head"
+          - "*mlp.gate"
+        # Activation observer (W4A4 only)
+        activation_observer: null
+        # vLLM quantization config JSON path (relative to project root)
+        quantization_config_path: null  # Specify in run script

--- a/qat/run_qwen3_30b_w4a16_megatron.sh
+++ b/qat/run_qwen3_30b_w4a16_megatron.sh
@@ -51,7 +51,7 @@ NNODES=4
 RAY_DATA_HOME=${RAY_DATA_HOME:-"${HOME_DIR}"}
 MODEL_PATH="/apps/models/Qwen3-30B-A3B-Base"
 CKPTS_DIR=${CKPTS_DIR:-"${RAY_DATA_HOME}/ckpts/${project_name}/${exp_name}"}
-TRAIN_FILE=${TRAIN_FILE:-"${RAY_DATA_HOME}/data/dapo-math-17k.parquet"}
+TRAIN_FILE=${TRAIN_FILE:-"${RAY_DATA_HOME}/data/dapo-math-17k-one.parquet"}
 TEST_FILE=${TEST_FILE:-"${RAY_DATA_HOME}/data/aime-2024.parquet"}
 
 # Algorithm
@@ -148,9 +148,9 @@ ACTOR=(
 )
 
 QAT=(
-    actor_rollout_ref.actor.qat.enable=${qat_enable}
-    actor_rollout_ref.actor.qat.mode=${qat_mode}
-    actor_rollout_ref.actor.qat.quantization_config_path="${qat_config_path}"
+    actor_rollout_ref.actor.megatron.qat.enable=${qat_enable}
+    actor_rollout_ref.actor.megatron.qat.mode=${qat_mode}
+    actor_rollout_ref.actor.megatron.qat.quantization_config_path="${qat_config_path}"
 )
 
 ROLLOUT=(
@@ -158,6 +158,7 @@ ROLLOUT=(
     actor_rollout_ref.rollout.enforce_eager=True
     actor_rollout_ref.rollout.calculate_log_probs=True
     actor_rollout_ref.rollout.gpu_memory_utilization=0.50
+    actor_rollout_ref.rollout.max_model_len=$(( max_prompt_length + max_response_length ))
     actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp}
     actor_rollout_ref.rollout.enable_chunked_prefill=True
     actor_rollout_ref.rollout.max_num_batched_tokens=$(( 1024 * 16 ))
@@ -186,12 +187,12 @@ PERF_OPT=(
     +actor_rollout_ref.actor.optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True
 )
 
-REWARD_MODEL=(
-    reward_model.reward_manager=dapo
-    reward_model.overlong_buffer.enable=${enable_overlong_buffer}
-    reward_model.overlong_buffer.len=${overlong_buffer_len}
-    reward_model.overlong_buffer.penalty_factor=${overlong_penalty_factor}
-    reward_model.overlong_buffer.log=False
+REWARD=(
+    reward.reward_manager.name=dapo
+    reward.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer}
+    reward.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len}
+    reward.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor}
+    reward.reward_kwargs.max_resp_len=${max_response_length}
 )
 
 TRAINER=(
@@ -207,6 +208,7 @@ TRAINER=(
     trainer.total_training_steps=500
     trainer.default_local_dir="${CKPTS_DIR}"
     trainer.resume_mode=auto
+    trainer.use_legacy_worker_impl=disable
 )
 
 FORWARD_ONLY_SETS=(
@@ -227,9 +229,10 @@ FORWARD_ONLY_SETS=(
 ################################################### start script ###################################################
 
 RAY_ADDRESS='http://127.0.0.1:8265' ray job submit --runtime-env=${RUNTIME_ENV} \
-    -- python3 -m verl.trainer.main_ppo \
-    --config-path="${WORKING_DIR}/recipe/qat/config" \
-    --config-name='dapo_qat_megatron_trainer' \
+    --working-dir "${WORKING_DIR}" \
+    -- python3 -m recipe.dapo.main_dapo \
+    --config-path "${WORKING_DIR}/recipe/qat/config" \
+    --config-name dapo_qat_megatron_trainer \
     "${DATA[@]}" \
     "${ALGORITHM[@]}" \
     "${MODEL[@]}" \
@@ -237,6 +240,6 @@ RAY_ADDRESS='http://127.0.0.1:8265' ray job submit --runtime-env=${RUNTIME_ENV} 
     "${QAT[@]}" \
     "${ROLLOUT[@]}" \
     "${PERF_OPT[@]}" \
-    "${REWARD_MODEL[@]}" \
+    "${REWARD[@]}" \
     "${TRAINER[@]}" \
     "${FORWARD_ONLY_SETS[@]}"

--- a/qat/run_qwen3_30b_w4a16_megatron_FFN_only.sh
+++ b/qat/run_qwen3_30b_w4a16_megatron_FFN_only.sh
@@ -148,10 +148,10 @@ ACTOR=(
 )
 
 QAT=(
-    actor_rollout_ref.actor.qat.enable=${qat_enable}
-    actor_rollout_ref.actor.qat.mode=${qat_mode}
-    actor_rollout_ref.actor.qat.quantization_config_path="${qat_config_path}"
-    'actor_rollout_ref.actor.qat.ignore_patterns=["lm_head", "*mlp.gate", "*self_attn*"]'
+    actor_rollout_ref.actor.megatron.qat.enable=${qat_enable}
+    actor_rollout_ref.actor.megatron.qat.mode=${qat_mode}
+    actor_rollout_ref.actor.megatron.qat.quantization_config_path="${qat_config_path}"
+    'actor_rollout_ref.actor.megatron.qat.ignore_patterns=["lm_head", "*mlp.gate", "*self_attn*"]'
 )
 
 ROLLOUT=(
@@ -159,6 +159,7 @@ ROLLOUT=(
     actor_rollout_ref.rollout.enforce_eager=True
     actor_rollout_ref.rollout.calculate_log_probs=True
     actor_rollout_ref.rollout.gpu_memory_utilization=0.50
+    actor_rollout_ref.rollout.max_model_len=$(( max_prompt_length + max_response_length ))
     actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp}
     actor_rollout_ref.rollout.enable_chunked_prefill=True
     actor_rollout_ref.rollout.max_num_batched_tokens=$(( 1024 * 16 ))
@@ -187,12 +188,12 @@ PERF_OPT=(
     +actor_rollout_ref.actor.optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True
 )
 
-REWARD_MODEL=(
-    reward_model.reward_manager=dapo
-    reward_model.overlong_buffer.enable=${enable_overlong_buffer}
-    reward_model.overlong_buffer.len=${overlong_buffer_len}
-    reward_model.overlong_buffer.penalty_factor=${overlong_penalty_factor}
-    reward_model.overlong_buffer.log=False
+REWARD=(
+    reward.reward_manager.name=dapo
+    reward.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer}
+    reward.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len}
+    reward.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor}
+    reward.reward_kwargs.max_resp_len=${max_response_length}
 )
 
 TRAINER=(
@@ -208,6 +209,7 @@ TRAINER=(
     trainer.total_training_steps=500
     trainer.default_local_dir="${CKPTS_DIR}"
     trainer.resume_mode=auto
+    trainer.use_legacy_worker_impl=disable
 )
 
 FORWARD_ONLY_SETS=(
@@ -228,9 +230,10 @@ FORWARD_ONLY_SETS=(
 ################################################### start script ###################################################
 
 RAY_ADDRESS='http://127.0.0.1:8265' ray job submit --runtime-env=${RUNTIME_ENV} \
-    -- python3 -m verl.trainer.main_ppo \
-    --config-path="${WORKING_DIR}/recipe/qat/config" \
-    --config-name='dapo_qat_megatron_trainer' \
+    --working-dir "${WORKING_DIR}" \
+    -- python3 -m recipe.dapo.main_dapo \
+    --config-path "${WORKING_DIR}/recipe/qat/config" \
+    --config-name dapo_qat_megatron_trainer \
     "${DATA[@]}" \
     "${ALGORITHM[@]}" \
     "${MODEL[@]}" \
@@ -238,6 +241,6 @@ RAY_ADDRESS='http://127.0.0.1:8265' ray job submit --runtime-env=${RUNTIME_ENV} 
     "${QAT[@]}" \
     "${ROLLOUT[@]}" \
     "${PERF_OPT[@]}" \
-    "${REWARD_MODEL[@]}" \
+    "${REWARD[@]}" \
     "${TRAINER[@]}" \
     "${FORWARD_ONLY_SETS[@]}"


### PR DESCRIPTION
### Summary
- Restructured QAT config to nest under actor_rollout_ref.actor.megatron.qat instead of actor_rollout_ref.actor.qat, matching the updated verl Megatron engine config hierarchy.
- Migrated reward config from legacy reward_model.* schema to the new reward.reward_manager / reward.reward_kwargs schema.
- Updated entry point from verl.trainer.main_ppo to recipe.dapo.main_dapo and added --working-dir flag.

### Changed Files

| File | Change |
|------|--------|
| `qat/config/dapo_qat_megatron_trainer.yaml` | Restructured QAT and reward config sections; added usage docs |
| `qat/run_qwen3_30b_w4a16_megatron.sh` | Updated config paths, entry point, and reward/rollout/trainer settings |
| `qat/run_qwen3_30b_w4a16_megatron_FFN_only.sh` | Same updates as above (FFN-only variant) |
