### PR TITLE
fix: ReactAgentLoop replace init_class with __init__. 

### DIFF
--- a/langgraph_agent/react_agent_loop.py
+++ b/langgraph_agent/react_agent_loop.py
@@ -89,22 +89,15 @@ class ReactAgentLoop(AgentLoopBase):
     NODES_PER_TURN = 2  # Each AI turn involves agent + tools nodes
     RECURSION_LIMIT_SAFETY_FACTOR = 1.5  # 50% buffer for edge cases
 
-    @classmethod
-    def init_class(cls, config, tokenizer, **kwargs):
-        if cls._class_initialized:
-            return
-        cls._class_initialized = True
-        print("Performing class-level ReactAgentLoop initialization")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.graph = self.build_graph()
 
-        # build graph
-        cls.graph = cls.build_graph()
-
-    @classmethod
-    def build_graph(cls) -> StateGraph:
+    def build_graph(self) -> StateGraph:
         workflow = StateGraph(MessagesState)
 
         workflow.add_node("agent", call_model)
-        workflow.add_node("tools", ToolNode(cls.tools))
+        workflow.add_node("tools", ToolNode(self.tools))
         workflow.set_entry_point("agent")
         workflow.add_conditional_edges(
             "agent",

--- a/langgraph_agent/test_react_agent_loop.py
+++ b/langgraph_agent/test_react_agent_loop.py
@@ -90,11 +90,9 @@ def get_temperature_date(location: str, date: str, unit: str = "celsius"):
 
 
 class TestReactAgentLoop(ReactAgentLoop):
-    @classmethod
-    def init_class(cls, config, tokenizer, **kwargs):
-        # TODO: find better way to configure tools
-        cls.tools = [get_current_temperature, get_temperature_date]
-        super().init_class(config, tokenizer, **kwargs)
+    def __init__(self, *args, **kwargs):
+        self.tools = [get_current_temperature, get_temperature_date]
+        super().__init__(*args, **kwargs)
 
 
 def test_react_agent(init_config):


### PR DESCRIPTION
## Problem
The init_class method in the parent class is not being triggered, causing self.tools to be undefined when model.bind_tools(self.tools, tool_choice="any") is called.

## Fix
update the recipe langgraph_agent to match the new architecture under the PR change [https://github.com/verl-project/verl/pull/4469](url).

## Test
Verified training runs with run_qwen2.5_3b.sh for 78 steps and get result val-core/lighteval/MATH/acc/mean@1: 0.998.
Verified pytest file with test_react_agent_loop.py and get passed result.