### PR TITLE
[refactor] pin verl versions of each recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # verl-recipe
 
-`verl-recipe` hosts recipes based on [verl](https://github.com/volcengine/verl) contributed by the community.
+`verl-recipe` hosts recipes based on [verl](https://github.com/verl-project/verl) contributed by the community.
 
 ## Usage
 
@@ -12,7 +12,55 @@ cd verl
 git submodule update --init --recursive recipe
 ```
 
-## Available Recipes
+## Required `verl` version per recipe
+
+Every recipe directory ships a small **`REQUIRED_VERL.txt`** next to its `README.md` (same filename everywhere). That file is the canonical place for:
+
+- upstream git URL (today [`verl-project/verl`](https://github.com/verl-project/verl), historically `volcengine/verl`),
+- whether the recipe **tracks `main`** (`pip install -e .` from the same tree) or **pins** a git commit / release tag,
+- a copy-pastable `pip install …` line when a pin exists.
+
+**Rolling recipes** (`MODE=rolling` and similar): `REQUIRED_VERL.txt` now lists **exact commit IDs** taken from this workspace when the file was last refreshed:
+
+- **`VERL_COMMIT`**: `git rev-parse HEAD` in the parent **verl** repository (core `pip install verl@git+…@VERL_COMMIT`).
+- **`RECIPE_SUBMODULE_COMMIT`**: `git rev-parse HEAD` inside the **`recipe/`** submodule checkout embedded at that verl revision.
+- **`RECIPE_FOLDER_LAST_COMMIT`**: `git log -1 --format=%H -- <folder>` inside **`recipe/`** for that recipe’s subdirectory only.
+
+Together these pin both the library and the bundled recipe tree. **`REFRESH=`** at the bottom of each file is the command line used to recompute the fields after you bump verl or the submodule.
+
+Each recipe `README.md` links to its `REQUIRED_VERL.txt` in a short **Required `verl` version** section. The repository root [`README.md`](../README.md) also points here for discoverability.
+
+| Recipe | `REQUIRED_VERL.txt` |
+| --- | --- |
+| char_count | [`recipe/char_count/REQUIRED_VERL.txt`](char_count/REQUIRED_VERL.txt) |
+| collabllm | [`recipe/collabllm/REQUIRED_VERL.txt`](collabllm/REQUIRED_VERL.txt) |
+| dapo | [`recipe/dapo/REQUIRED_VERL.txt`](dapo/REQUIRED_VERL.txt) |
+| deepeyes | [`recipe/deepeyes/REQUIRED_VERL.txt`](deepeyes/REQUIRED_VERL.txt) |
+| entropy | [`recipe/entropy/REQUIRED_VERL.txt`](entropy/REQUIRED_VERL.txt) |
+| fapo | [`recipe/fapo/REQUIRED_VERL.txt`](fapo/REQUIRED_VERL.txt) |
+| fault_recover | [`recipe/fault_recover/REQUIRED_VERL.txt`](fault_recover/REQUIRED_VERL.txt) |
+| flash_rl_ascend | [`recipe/flash_rl_ascend/REQUIRED_VERL.txt`](flash_rl_ascend/REQUIRED_VERL.txt) |
+| flowrl | [`recipe/flowrl/REQUIRED_VERL.txt`](flowrl/REQUIRED_VERL.txt) |
+| genrm_remote | [`recipe/genrm_remote/REQUIRED_VERL.txt`](genrm_remote/REQUIRED_VERL.txt) |
+| gkd/megatron | [`recipe/gkd/megatron/REQUIRED_VERL.txt`](gkd/megatron/REQUIRED_VERL.txt) |
+| gvpo | [`recipe/gvpo/REQUIRED_VERL.txt`](gvpo/REQUIRED_VERL.txt) |
+| infigui-g1 | [`recipe/infigui-g1/REQUIRED_VERL.txt`](infigui-g1/REQUIRED_VERL.txt) |
+| langgraph_agent | [`recipe/langgraph_agent/REQUIRED_VERL.txt`](langgraph_agent/REQUIRED_VERL.txt) |
+| minicpmo | [`recipe/minicpmo/REQUIRED_VERL.txt`](minicpmo/REQUIRED_VERL.txt) |
+| open_math_reasoning | [`recipe/open_math_reasoning/REQUIRED_VERL.txt`](open_math_reasoning/REQUIRED_VERL.txt) |
+| prime | [`recipe/prime/REQUIRED_VERL.txt`](prime/REQUIRED_VERL.txt) |
+| qat | [`recipe/qat/REQUIRED_VERL.txt`](qat/REQUIRED_VERL.txt) |
+| r1 | [`recipe/r1/REQUIRED_VERL.txt`](r1/REQUIRED_VERL.txt) |
+| r1_ascend | [`recipe/r1_ascend/REQUIRED_VERL.txt`](r1_ascend/REQUIRED_VERL.txt) |
+| rep_exp | [`recipe/rep_exp/REQUIRED_VERL.txt`](rep_exp/REQUIRED_VERL.txt) |
+| retool | [`recipe/retool/REQUIRED_VERL.txt`](retool/REQUIRED_VERL.txt) |
+| specRL/histoSpec | [`recipe/specRL/histoSpec/REQUIRED_VERL.txt`](specRL/histoSpec/REQUIRED_VERL.txt) |
+| spin | [`recipe/spin/REQUIRED_VERL.txt`](spin/REQUIRED_VERL.txt) |
+| spo | [`recipe/spo/REQUIRED_VERL.txt`](spo/REQUIRED_VERL.txt) |
+| sppo | [`recipe/sppo/REQUIRED_VERL.txt`](sppo/REQUIRED_VERL.txt) |
+| swe_agent | [`recipe/swe_agent/REQUIRED_VERL.txt`](swe_agent/REQUIRED_VERL.txt) |
+
+## Available Recipes (high level)
 
 - [retool](https://github.com/verl-project/verl-recipe/tree/main/retool): Reinforcement Learning for Strategic Tool Use in LLMs
 - [langgraph_agent](https://github.com/verl-project/verl-recipe/tree/main/langgraph_agent): A tiny example to demonstrate multi-turn rollout with [LangGraph ReactAgent](https://langchain-ai.github.io/langgraph/agents/overview/) to solve math expression.
@@ -23,14 +71,14 @@ git submodule update --init --recursive recipe
 
 ### Version Specification
 
-Recipes are recommended to specify the verl version required, e.g.,
+Add or update **`REQUIRED_VERL.txt`** whenever a recipe gains a new tested pin or intentionally moves forward on `main`. Examples of valid `pip` forms:
 
 ```
 # release version
 verl==0.6.0
 
 # dev version
-verl@git+https://github.com/volcengine/verl.git@313dfdb2199124a37189e32e6d4a6c654379f2d4
+verl@git+https://github.com/verl-project/verl.git@313dfdb2199124a37189e32e6d4a6c654379f2d4
 ```
 
 ### Code Linting and Formatting

--- a/README.md
+++ b/README.md
@@ -30,6 +30,37 @@ Together these pin both the library and the bundled recipe tree. **`REFRESH=`** 
 
 Each recipe `README.md` links to its `REQUIRED_VERL.txt` in a short **Required `verl` version** section. The repository root [`README.md`](../README.md) also points here for discoverability.
 
+### One-shot installer: [`install_verl.sh`](install_verl.sh)
+
+`install_verl.sh` reads a recipe's `REQUIRED_VERL.txt` and installs the pinned core `verl` for you. It understands every `MODE=` value listed above and prints the command it will run before executing it (use `--show` for a dry-run).
+
+```bash
+# From the root of this repo (the directory containing install_verl.sh):
+
+# List every recipe + its pinned `pip install` line
+./install_verl.sh --list
+
+# Dry-run: see exactly which pip command a recipe would execute
+./install_verl.sh --recipe dapo --show
+
+# Install the pinned verl core for a recipe via pip (default)
+./install_verl.sh --recipe retool
+
+# Clone upstream verl at the pinned commit, init the recipe submodule,
+# and `pip install -e .` from the checkout (useful when you want an
+# editable install or plan to modify verl itself).
+./install_verl.sh --recipe langgraph_agent --method git --dest ./verl
+
+# Recipes that expose multiple variants: pick one with --option
+./install_verl.sh --recipe dapo   --option reproduction   # DAPO paper SHA
+./install_verl.sh --recipe flowrl --option A              # FlowRL v0.4.0 tag
+./install_verl.sh --recipe spin   --option baseline       # SPIN v0.3.0.post1
+```
+
+Flags: `--recipe NAME` (e.g. `gkd/megatron`, `specRL/histoSpec`) or `--file PATH/TO/REQUIRED_VERL.txt`, `--method pip|git` (default `pip`), `--dest DIR` (default `./verl`, only used with `--method git`), `--show` (dry-run), `--yes` (skip confirmation), `--list`, `--help`.
+
+The script requires only `bash`, `git`, `awk`, and `pip`/`pip3` on `PATH`. It does **not** `source` or `eval` the `REQUIRED_VERL.txt` file — values are extracted with `awk` and the exact command to be executed is echoed before it runs.
+
 | Recipe | `REQUIRED_VERL.txt` |
 | --- | --- |
 | char_count | [`recipe/char_count/REQUIRED_VERL.txt`](char_count/REQUIRED_VERL.txt) |

--- a/char_count/README.md
+++ b/char_count/README.md
@@ -1,4 +1,9 @@
 # Char Count
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 ## Introduction
 Char count is a simple NLP task. We create it for beginners to grasp the idea of RLVR. The task can be trained using a tiny model (e.g., https://huggingface.co/HuggingFaceTB/SmolLM2-135M) on a consumer GPU with only 8GB.
 

--- a/char_count/REQUIRED_VERL.txt
+++ b/char_count/REQUIRED_VERL.txt
@@ -1,0 +1,6 @@
+# char_count — tested PyPI / tag release
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_tag
+TAG=v0.6.1
+COMMIT=d62da4950573d7a4b7ef2362337952e7ab59e78d
+PIP_INSTALL=pip install verl==0.6.1

--- a/collabllm/README.md
+++ b/collabllm/README.md
@@ -1,4 +1,8 @@
 # CollabLLM
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 This repository implements [CollabLLM](https://arxiv.org/pdf/2502.00640) (ICML 2025) using the verl framework. For the original implementation, see the [CollabLLM repository](https://github.com/Wuyxin/collabllm).
 

--- a/collabllm/REQUIRED_VERL.txt
+++ b/collabllm/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# collabllm — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=collabllm
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- collabllm)
+

--- a/dapo/README.md
+++ b/dapo/README.md
@@ -1,4 +1,8 @@
 # Recipe: Decoupled Clip and Dynamic Sampling Policy Optimization (DAPO)
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 > Open-Source Algorithm Implementation & Expriement Running: [Yuxuan Tong](https://tongyx361.github.io/), [Guangming Sheng](https://hk.linkedin.com/in/guangming-sheng-b50640211)
 

--- a/dapo/REQUIRED_VERL.txt
+++ b/dapo/REQUIRED_VERL.txt
@@ -1,0 +1,13 @@
+# DAPO — published reproduction tables use this commit; main-branch recipe tracks latest verl
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=reproduction_commit
+REPRODUCTION_COMMIT=4f80e465c2ec79ab9c3c30ec74b9745de61d0490
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@4f80e465c2ec79ab9c3c30ec74b9745de61d0490
+NOTES=For paper reproduction use REPRODUCTION_COMMIT. For the current mainline recipe in this workspace, use the rolling pins below.
+ROLLING_VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+ROLLING_PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=dapo
+RECIPE_FOLDER_LAST_COMMIT=8f9e7ac93acac57f6ef7e8dffa3de788d148a09a
+REFRESH=Recompute rolling pins from your verl clone; reproduction SHA is fixed by the DAPO paper run table.
+

--- a/deepeyes/README.md
+++ b/deepeyes/README.md
@@ -1,4 +1,8 @@
 # DeepEyes: Incentivizing "Thinking with Images" via Reinforcement Learning
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 This directory contains the implementation for reproducing the DeepEyes paper within the verl framework, supporting multi-turn visual tool calls. This implementation is based on the original [DeepEyes paper](https://arxiv.org/abs/2505.14362) and its [official implementation](https://github.com/Visual-Agent/DeepEyes), integrated with the multi-modal and multi-turn capabilities of the verl framework.
 

--- a/deepeyes/REQUIRED_VERL.txt
+++ b/deepeyes/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# deepeyes — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=deepeyes
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=ca0df7ab9b551ff3851aa37f0fdee39ba8f97419
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- deepeyes)
+

--- a/entropy/README.md
+++ b/entropy/README.md
@@ -1,4 +1,8 @@
 <div align="center">
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 # The Entropy Mechanism of Reinforcement Learning for Large Language Model Reasoning.
 

--- a/entropy/REQUIRED_VERL.txt
+++ b/entropy/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# entropy — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=entropy
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- entropy)
+

--- a/fapo/README.md
+++ b/fapo/README.md
@@ -1,4 +1,9 @@
 <p align="center">
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 <h1 align="center">FAPO: Flawed-Aware Policy Optimization for Efficient and Reliable Reasoning</h1>
 
 <p align="center">

--- a/fapo/REQUIRED_VERL.txt
+++ b/fapo/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# fapo — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=fapo
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- fapo)
+

--- a/fault_recover/README.md
+++ b/fault_recover/README.md
@@ -1,4 +1,8 @@
 # Recipe: Tokens saving and Auto Fault Recover for Rollout
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 ## Design
 
@@ -28,7 +32,7 @@ train
 
 ```bash
 # dev version
-pip install verl@git+https://github.com/volcengine/verl.git@b97ebfd5062223337ae065c2250f8ab5c0e08e5e
+pip install verl@git+https://github.com/verl-project/verl.git@b97ebfd5062223337ae065c2250f8ab5c0e08e5e
 ```
 
 ## Quickstart

--- a/fault_recover/REQUIRED_VERL.txt
+++ b/fault_recover/REQUIRED_VERL.txt
@@ -1,0 +1,5 @@
+# fault_recover — README pins a specific commit
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_commit
+COMMIT=b97ebfd5062223337ae065c2250f8ab5c0e08e5e
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@b97ebfd5062223337ae065c2250f8ab5c0e08e5e

--- a/flash_rl_ascend/README.md
+++ b/flash_rl_ascend/README.md
@@ -1,4 +1,8 @@
 ## 在线量化权重：
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 介绍在昇腾设备上，使用 [Flash-RL](https://github.com/yaof20/Flash-RL) 工具，修改推理后端，通过比较 INT8 模型和 BF16 模型，对权重和激活值执行在线量化。下文以 Qwen3-30B int8 为例，在 NPU 上跑通端到端功能。
 

--- a/flash_rl_ascend/REQUIRED_VERL.txt
+++ b/flash_rl_ascend/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# flash_rl_ascend — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=flash_rl_ascend
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=0adf8a98797283a299f1fe0dfdabe98046574609
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- flash_rl_ascend)
+

--- a/flowrl/README.md
+++ b/flowrl/README.md
@@ -1,4 +1,9 @@
 <h1 align="center" style="color:#1976D2; font-size:42px; font-weight:bold; margin-bottom:0;">
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
   FlowRL
 </h1>
 

--- a/flowrl/REQUIRED_VERL.txt
+++ b/flowrl/REQUIRED_VERL.txt
@@ -1,0 +1,15 @@
+# FlowRL — README offers two tracks
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=mixed
+OPTION_A_TAG=v0.4.0
+OPTION_A_COMMIT=0758489422e8d41a89e6c36d4c477714520f0dcc
+OPTION_A_PIP=pip install verl==0.4.0
+OPTION_B=rolling_main
+OPTION_B_VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+OPTION_B_PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+OPTION_B_RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+OPTION_B_RECIPE_FOLDER=flowrl
+OPTION_B_RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+OPTION_B_PIP=From repo root with this recipe on main: pip install -e .
+NOTES=Option A pins historical verl; Option B pins this workspace's verl core (OPTION_B_VERL_COMMIT) and records the recipe submodule/folder commits.
+

--- a/genrm_remote/README.md
+++ b/genrm_remote/README.md
@@ -1,4 +1,8 @@
 # Generative Reward Model
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 ## Scripts
 

--- a/genrm_remote/REQUIRED_VERL.txt
+++ b/genrm_remote/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# genrm_remote — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=genrm_remote
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- genrm_remote)
+

--- a/gkd/megatron/README.md
+++ b/gkd/megatron/README.md
@@ -1,4 +1,8 @@
 # Recipe: Async On-Policy Knowledge Distillation Trainer
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 **Authors:** Brilliant Hanabi, furunding
 

--- a/gkd/megatron/REQUIRED_VERL.txt
+++ b/gkd/megatron/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# gkd/megatron — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=gkd/megatron
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=a9e75bbe8da8c7548bc60831945df65970705885
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- gkd/megatron)
+

--- a/gvpo/README.md
+++ b/gvpo/README.md
@@ -1,4 +1,8 @@
 <div align="center">
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 # GVPO: Group Variance Policy Optimization
 

--- a/gvpo/REQUIRED_VERL.txt
+++ b/gvpo/REQUIRED_VERL.txt
@@ -1,0 +1,7 @@
+# GVPO — README documents verl v0.6.0
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_tag
+TAG=v0.6.0
+COMMIT=ddd86f527a4af75095e4677b02b5aa272913a088
+PIP_INSTALL=pip install verl==0.6.0
+NOTES=GRPO example alignment referenced in README uses the same v0.6.0 tag commit.

--- a/infigui-g1/README.md
+++ b/infigui-g1/README.md
@@ -1,4 +1,8 @@
 # Recipe for InfiGUI-G1
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 This directory contains the official implementation for the paper [InfiGUI-G1: Advancing GUI Grounding with Adaptive Exploration Policy Optimization](https://arxiv.org/abs/2508.05731).
 

--- a/infigui-g1/REQUIRED_VERL.txt
+++ b/infigui-g1/REQUIRED_VERL.txt
@@ -1,0 +1,7 @@
+# infigui-g1 — Docker image tag references verl 0.5.x line
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_tag
+TAG=v0.5.0
+COMMIT=8fdc4d3f202f41461f4de9f42a637228e342668b
+PIP_INSTALL=pip install verl==0.5.0
+NOTES=Scripts reference Docker image verlai/verl:...verl0.5...; pin to v0.5.0 unless you intentionally track main.

--- a/install_verl.sh
+++ b/install_verl.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# install_verl.sh — clone and/or install the `verl` version required by a recipe.
+#
+# Every recipe directory in this repo ships a REQUIRED_VERL.txt file. This script
+# reads that file and either runs the recorded `pip install ...` line (default) or
+# performs a full `git clone` + checkout + `pip install -e .` of the upstream verl
+# repository at the pinned commit.
+#
+# Usage:
+#   ./install_verl.sh --recipe NAME [options]
+#   ./install_verl.sh --file  PATH/TO/REQUIRED_VERL.txt [options]
+#   ./install_verl.sh --list
+#   ./install_verl.sh --help
+#
+# Options:
+#   --recipe NAME      Recipe directory (e.g. dapo, gkd/megatron, specRL/histoSpec).
+#   --file   PATH      Explicit path to a REQUIRED_VERL.txt file.
+#   --method pip|git   Install method (default: pip).
+#                      * pip: run the recipe's recorded PIP_INSTALL line.
+#                      * git: clone UPSTREAM, checkout the pinned commit, then
+#                             `pip install -e .` from the checkout.
+#   --option NAME      Which variant to pick when the recipe exposes several:
+#                        MODE=mixed               -> A | B          (default: B / rolling)
+#                        MODE=rolling_with_baseline -> rolling | baseline (default: rolling)
+#                        MODE=dapo reproduction    -> rolling | reproduction (default: rolling)
+#                      Ignored for other MODEs.
+#   --dest DIR         Directory to clone verl into when --method git is used
+#                      (default: ./verl).
+#   --show             Print the resolved plan and exit without running anything.
+#   --yes              Skip the confirmation prompt before executing commands.
+#   --list             List every recipe in this repo with its pinned verl spec.
+#   --help             Show this help and exit.
+#
+# Notes:
+#   - This script does NOT `source` or `eval` the REQUIRED_VERL.txt file. Values are
+#     extracted with `awk` and the commands are printed before being run; with
+#     `--show` nothing is executed.
+#   - Run from the recipe-repo root (the directory containing this script) so that
+#     --recipe NAME resolves to ./NAME/REQUIRED_VERL.txt.
+#   - Requires: bash, git, awk, pip (or pip3). `pipx run` or a pre-activated
+#     virtualenv is fine; the pip executable is detected automatically.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+print_help() {
+    # Print the banner comment (lines 2..41), stripping the leading `# ` / `#`.
+    sed -n '2,41p' "${BASH_SOURCE[0]}" | sed -E 's/^#( |$)//'
+}
+
+log()  { printf '[install_verl] %s\n' "$*" >&2; }
+die()  { printf '[install_verl] error: %s\n' "$*" >&2; exit 1; }
+
+# get_field FILE KEY -> prints the value of the first `KEY=...` line.
+# - ignores lines that start with `#`
+# - trims leading/trailing whitespace in the value
+# - prints nothing (exit 0) if the key is absent
+get_field() {
+    local file="$1" key="$2"
+    awk -v k="$key" '
+        /^[[:space:]]*#/ { next }
+        {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            n = index(line, "=")
+            if (n == 0) next
+            name = substr(line, 1, n-1)
+            val  = substr(line, n+1)
+            sub(/[[:space:]]+$/, "", val)
+            if (name == k) { print val; exit }
+        }
+    ' "$file"
+}
+
+detect_pip() {
+    if [[ -n "${PIP:-}" ]]; then
+        printf '%s\n' "$PIP"
+    elif command -v pip >/dev/null 2>&1; then
+        printf 'pip\n'
+    elif command -v pip3 >/dev/null 2>&1; then
+        printf 'pip3\n'
+    else
+        die "neither pip nor pip3 is on PATH; set PIP=... or activate your env"
+    fi
+}
+
+# Rewrite `pip install ...` to use the detected pip binary.
+rewrite_pip_cmd() {
+    local cmd="$1" pip_bin="$2"
+    if [[ "$cmd" == pip\ install* ]]; then
+        printf '%s %s\n' "$pip_bin" "${cmd#pip }"
+    elif [[ "$cmd" == pip3\ install* ]]; then
+        printf '%s %s\n' "$pip_bin" "${cmd#pip3 }"
+    else
+        printf '%s\n' "$cmd"
+    fi
+}
+
+list_recipes() {
+    # shellcheck disable=SC2012  # ls is fine here; we only need a sorted list
+    # Find every REQUIRED_VERL.txt and print "recipe_name <tab> pip install line".
+    find "$SCRIPT_DIR" -type f -name REQUIRED_VERL.txt \
+        -not -path "$SCRIPT_DIR/.git/*" \
+        | sort \
+        | while read -r f; do
+            local rel name mode pip_line
+            rel="${f#"$SCRIPT_DIR"/}"
+            name="${rel%/REQUIRED_VERL.txt}"
+            mode="$(get_field "$f" MODE)"
+            pip_line="$(get_field "$f" PIP_INSTALL)"
+            if [[ -z "$pip_line" ]]; then
+                pip_line="$(get_field "$f" ROLLING_PIP_INSTALL)"
+            fi
+            if [[ -z "$pip_line" ]]; then
+                pip_line="$(get_field "$f" OPTION_B_PIP_INSTALL)"
+            fi
+            printf '%-32s  MODE=%-24s  %s\n' "$name" "${mode:-?}" "${pip_line:-?}"
+        done
+}
+
+# resolve_spec FILE OPTION
+# Populates these globals (declared in main scope):
+#   R_MODE R_UPSTREAM R_COMMIT R_TAG R_PIP_INSTALL R_GIT_SETUP R_LABEL
+resolve_spec() {
+    local file="$1" option="$2"
+    R_MODE="$(get_field "$file" MODE)"
+    R_UPSTREAM="$(get_field "$file" UPSTREAM)"
+    R_COMMIT=""
+    R_TAG=""
+    R_PIP_INSTALL=""
+    R_GIT_SETUP=""
+    R_LABEL=""
+
+    case "$R_MODE" in
+        rolling)
+            R_LABEL="rolling@$(get_field "$file" VERL_COMMIT)"
+            R_COMMIT="$(get_field "$file" VERL_COMMIT)"
+            R_PIP_INSTALL="$(get_field "$file" PIP_INSTALL)"
+            R_GIT_SETUP="$(get_field "$file" GIT_SETUP)"
+            ;;
+        pinned_tag)
+            R_TAG="$(get_field "$file" TAG)"
+            R_COMMIT="$(get_field "$file" COMMIT)"
+            R_LABEL="pinned_tag@${R_TAG:-${R_COMMIT}}"
+            R_PIP_INSTALL="$(get_field "$file" PIP_INSTALL)"
+            R_GIT_SETUP="$(get_field "$file" GIT_SETUP)"
+            ;;
+        pinned_commit)
+            R_COMMIT="$(get_field "$file" COMMIT)"
+            R_LABEL="pinned_commit@${R_COMMIT}"
+            R_PIP_INSTALL="$(get_field "$file" PIP_INSTALL)"
+            R_GIT_SETUP="$(get_field "$file" GIT_SETUP)"
+            ;;
+        reproduction_commit)
+            # DAPO-style file: a fixed reproduction SHA + a rolling main pin.
+            local want="${option:-rolling}"
+            case "$want" in
+                reproduction|repro)
+                    R_COMMIT="$(get_field "$file" REPRODUCTION_COMMIT)"
+                    R_LABEL="reproduction@${R_COMMIT}"
+                    R_PIP_INSTALL="$(get_field "$file" PIP_INSTALL)"
+                    ;;
+                rolling|"")
+                    R_COMMIT="$(get_field "$file" ROLLING_VERL_COMMIT)"
+                    [[ -z "$R_COMMIT" ]] && R_COMMIT="$(get_field "$file" VERL_COMMIT)"
+                    R_LABEL="rolling@${R_COMMIT}"
+                    R_PIP_INSTALL="$(get_field "$file" ROLLING_PIP_INSTALL)"
+                    [[ -z "$R_PIP_INSTALL" ]] && R_PIP_INSTALL="$(get_field "$file" PIP_INSTALL)"
+                    ;;
+                *) die "MODE=reproduction_commit expects --option rolling|reproduction (got '$want')" ;;
+            esac
+            R_GIT_SETUP="$(get_field "$file" GIT_SETUP)"
+            ;;
+        mixed)
+            local want="${option:-B}"
+            case "$want" in
+                A|a)
+                    R_TAG="$(get_field "$file" OPTION_A_TAG)"
+                    R_COMMIT="$(get_field "$file" OPTION_A_COMMIT)"
+                    R_PIP_INSTALL="$(get_field "$file" OPTION_A_PIP)"
+                    R_LABEL="optionA@${R_TAG:-$R_COMMIT}"
+                    ;;
+                B|b|rolling|"")
+                    R_COMMIT="$(get_field "$file" OPTION_B_VERL_COMMIT)"
+                    R_PIP_INSTALL="$(get_field "$file" OPTION_B_PIP_INSTALL)"
+                    [[ -z "$R_PIP_INSTALL" ]] && R_PIP_INSTALL="$(get_field "$file" OPTION_B_PIP)"
+                    R_LABEL="optionB/rolling@${R_COMMIT}"
+                    ;;
+                *) die "MODE=mixed expects --option A|B (got '$want')" ;;
+            esac
+            R_GIT_SETUP="$(get_field "$file" GIT_SETUP)"
+            ;;
+        rolling_with_baseline)
+            local want="${option:-rolling}"
+            case "$want" in
+                rolling|"")
+                    R_COMMIT="$(get_field "$file" ROLLING_VERL_COMMIT)"
+                    R_PIP_INSTALL="$(get_field "$file" ROLLING_PIP_INSTALL)"
+                    R_GIT_SETUP="$(get_field "$file" ROLLING_GIT_SETUP)"
+                    R_LABEL="rolling@${R_COMMIT}"
+                    ;;
+                baseline|reference)
+                    R_TAG="$(get_field "$file" REFERENCE_TAG)"
+                    R_COMMIT="$(get_field "$file" REFERENCE_COMMIT)"
+                    # No direct PIP line recorded; synthesize one from upstream+commit.
+                    if [[ -n "$R_COMMIT" && -n "$R_UPSTREAM" ]]; then
+                        R_PIP_INSTALL="pip install verl@git+${R_UPSTREAM}@${R_COMMIT}"
+                    fi
+                    R_LABEL="baseline@${R_TAG:-$R_COMMIT}"
+                    ;;
+                *) die "MODE=rolling_with_baseline expects --option rolling|baseline (got '$want')" ;;
+            esac
+            ;;
+        "")
+            die "$(printf 'no MODE= field in %s' "$file")"
+            ;;
+        *)
+            # Unknown / future mode. Fall back to whatever PIP_INSTALL is present.
+            R_PIP_INSTALL="$(get_field "$file" PIP_INSTALL)"
+            R_COMMIT="$(get_field "$file" COMMIT)"
+            [[ -z "$R_COMMIT" ]] && R_COMMIT="$(get_field "$file" VERL_COMMIT)"
+            R_GIT_SETUP="$(get_field "$file" GIT_SETUP)"
+            R_LABEL="${R_MODE}@${R_COMMIT:-unknown}"
+            log "unknown MODE=$R_MODE; best-effort using PIP_INSTALL=${R_PIP_INSTALL:-<missing>}"
+            ;;
+    esac
+
+    [[ -n "$R_UPSTREAM" ]] || R_UPSTREAM="https://github.com/verl-project/verl.git"
+}
+
+confirm() {
+    local prompt="$1"
+    if [[ "${ASSUME_YES:-0}" == "1" ]]; then return 0; fi
+    read -r -p "$prompt [y/N] " ans
+    [[ "$ans" == "y" || "$ans" == "Y" ]]
+}
+
+run_cmd() {
+    local cmd="$1"
+    log "+ $cmd"
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then return 0; fi
+    bash -c "$cmd"
+}
+
+install_via_pip() {
+    local pip_bin rewritten
+    if [[ -z "$R_PIP_INSTALL" ]]; then
+        die "no PIP_INSTALL line is available for MODE=$R_MODE in this recipe"
+    fi
+    pip_bin="$(detect_pip)"
+    rewritten="$(rewrite_pip_cmd "$R_PIP_INSTALL" "$pip_bin")"
+    run_cmd "$rewritten"
+}
+
+install_via_git() {
+    local dest="$1" pip_bin
+    pip_bin="$(detect_pip)"
+
+    # If the recipe recorded a self-contained GIT_SETUP line, run that verbatim
+    # (it already does clone + checkout + submodule init + cd, which is the
+    # canonical sequence the README expects).
+    if [[ -n "$R_GIT_SETUP" ]]; then
+        # Only run if the caller didn't override dest away from the default.
+        if [[ "$dest" != "verl" && "$dest" != "./verl" ]]; then
+            log "note: ignoring recorded GIT_SETUP because --dest=$dest differs from its default"
+        else
+            run_cmd "$R_GIT_SETUP"
+            run_cmd "cd verl && $pip_bin install -e ."
+            return
+        fi
+    fi
+
+    [[ -n "$R_COMMIT" ]] || die "MODE=$R_MODE has no commit to check out; use --method pip instead"
+
+    if [[ -d "$dest/.git" ]]; then
+        run_cmd "cd '$dest' && git fetch --tags --depth=1 origin '$R_COMMIT' || git fetch --tags origin"
+        run_cmd "cd '$dest' && git checkout '$R_COMMIT'"
+    else
+        run_cmd "git clone '$R_UPSTREAM' '$dest'"
+        run_cmd "cd '$dest' && git checkout '$R_COMMIT'"
+    fi
+    # Bring the recipe submodule to the matching revision so relative imports work.
+    run_cmd "cd '$dest' && git submodule update --init --recursive recipe || true"
+    run_cmd "cd '$dest' && $pip_bin install -e ."
+}
+
+main() {
+    local recipe="" file="" method="pip" option="" dest="verl" show=0
+    while (($#)); do
+        case "$1" in
+            --recipe) recipe="${2:?}"; shift 2 ;;
+            --file)   file="${2:?}";   shift 2 ;;
+            --method) method="${2:?}"; shift 2 ;;
+            --option) option="${2:?}"; shift 2 ;;
+            --dest)   dest="${2:?}";   shift 2 ;;
+            --show)   show=1; shift ;;
+            --yes|-y) ASSUME_YES=1; shift ;;
+            --list)   list_recipes; exit 0 ;;
+            -h|--help) print_help; exit 0 ;;
+            *) die "unknown argument: $1 (try --help)" ;;
+        esac
+    done
+
+    if [[ -z "$recipe" && -z "$file" ]]; then
+        print_help
+        exit 2
+    fi
+
+    if [[ -z "$file" ]]; then
+        file="$SCRIPT_DIR/$recipe/REQUIRED_VERL.txt"
+    fi
+    [[ -f "$file" ]] || die "REQUIRED_VERL.txt not found at: $file"
+
+    # Declared here so resolve_spec can set them in this scope.
+    local R_MODE R_UPSTREAM R_COMMIT R_TAG R_PIP_INSTALL R_GIT_SETUP R_LABEL
+    resolve_spec "$file" "$option"
+
+    cat >&2 <<EOF
+[install_verl] file:     $file
+[install_verl] MODE:     $R_MODE
+[install_verl] upstream: $R_UPSTREAM
+[install_verl] resolved: $R_LABEL
+[install_verl] method:   $method
+[install_verl] pip line: ${R_PIP_INSTALL:-<none>}
+EOF
+
+    if [[ "$show" == "1" ]]; then
+        DRY_RUN=1
+        case "$method" in
+            pip) install_via_pip ;;
+            git) install_via_git "$dest" ;;
+            *)   die "--method must be pip or git (got '$method')" ;;
+        esac
+        return 0
+    fi
+
+    case "$method" in
+        pip)
+            if ! confirm "Proceed with pip install?"; then die "aborted"; fi
+            install_via_pip
+            ;;
+        git)
+            if ! confirm "Proceed with git clone into '$dest' + pip install -e .?"; then die "aborted"; fi
+            install_via_git "$dest"
+            ;;
+        *) die "--method must be pip or git (got '$method')" ;;
+    esac
+
+    log "done."
+}
+
+main "$@"

--- a/langgraph_agent/README.md
+++ b/langgraph_agent/README.md
@@ -1,0 +1,7 @@
+# LangGraph agent recipe
+
+This package hosts the LangGraph-based agent-loop example. See [`example/README.md`](example/README.md) for the walkthrough and dataset scripts.
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.

--- a/langgraph_agent/REQUIRED_VERL.txt
+++ b/langgraph_agent/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# langgraph_agent — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=langgraph_agent
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=0375dbf4ed22281d9af5c89bbaee461f9056f43f
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- langgraph_agent)
+

--- a/langgraph_agent/example/README.md
+++ b/langgraph_agent/example/README.md
@@ -2,6 +2,10 @@
 
 MathExpression is a tiny example to demonstrate multi-turn rollout with [LangGraph ReactAgent](https://langchain-ai.github.io/langgraph/agents/overview/).
 
+## Required `verl` version
+
+See [`../REQUIRED_VERL.txt`](../REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 ### Define react agent with tool
 Firstly, to force ReactAgent to evaluate math expression by tool, we define a special operand `@`:
 ```python

--- a/minicpmo/README.md
+++ b/minicpmo/README.md
@@ -1,0 +1,8 @@
+# Minicpmo recipe
+
+This directory contains the `minicpmo` recipe code.
+
+## Required `verl` version
+
+See [`./REQUIRED_VERL.txt`](./REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+

--- a/minicpmo/REQUIRED_VERL.txt
+++ b/minicpmo/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# minicpmo — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=minicpmo
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- minicpmo)
+

--- a/open_math_reasoning/README.md
+++ b/open_math_reasoning/README.md
@@ -1,4 +1,9 @@
 # Open math reasoning
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 ## Introduction
 In this recipe, we perform SFT on the [open math reasoning](https://huggingface.co/datasets/nvidia/OpenMathReasoning) dataset using the new SFT trainer with backend agostic model engine. Note that our goal is not to replicate the [AIMO-2 Winning Solution](https://arxiv.org/abs/2504.16891) work, but to demonstrate a SFT demo from end to end.
 

--- a/open_math_reasoning/REQUIRED_VERL.txt
+++ b/open_math_reasoning/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# open_math_reasoning — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=open_math_reasoning
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- open_math_reasoning)
+

--- a/prime/README.md
+++ b/prime/README.md
@@ -1,0 +1,8 @@
+# PRIME recipe
+
+This directory contains the `prime` (PRIME) recipe code.
+
+## Required `verl` version
+
+See [`./REQUIRED_VERL.txt`](./REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+

--- a/prime/REQUIRED_VERL.txt
+++ b/prime/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# prime — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=prime
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=ccdb8d140dfc540761a9b209b854dbd2c0011e7e
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- prime)
+

--- a/qat/README.md
+++ b/qat/README.md
@@ -1,4 +1,8 @@
 # NVFP4 QAT (Quantization-Aware Training)
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 This module provides **NVFP4 W4A16 Quantization-Aware Training (QAT)**, enabling seamless integration between distributed training and vLLM inference engine. This allows **NVFP4 quantized** inference during training without causing KL divergence explosion.
 

--- a/qat/REQUIRED_VERL.txt
+++ b/qat/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# qat — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=qat
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- qat)
+

--- a/r1/README.md
+++ b/r1/README.md
@@ -1,4 +1,8 @@
 # DeepSeek R1 Reproduction
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 This recipe is under development, if you are interested, checkout the TODO list and join this project! https://github.com/volcengine/verl/issues/708 
 

--- a/r1/REQUIRED_VERL.txt
+++ b/r1/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# r1 — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=r1
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- r1)
+

--- a/r1_ascend/README.md
+++ b/r1_ascend/README.md
@@ -1,4 +1,9 @@
 # DeepSeek-R1-Zero on Ascend NPU
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 This recipe provides a sample for fine-tuning the Deepseek-V3-Base model using Reinforcement Learning from Human Feedback (RLHF) on Ascend NPUs, specifically utilizing the GRPO algorithm with rule-based rewards on the deepscaler dataset.
 
 ## Implementation Details

--- a/r1_ascend/README_zh.md
+++ b/r1_ascend/README_zh.md
@@ -1,6 +1,10 @@
 # DeepSeek-R1-Zero on Ascend NPU
 本recipe是基于Deepseek-V3-Base模型在NPU上进行RLHF后训练的样例，基于GRPO与规则奖励，使用deepscaler数据集。
 
+## 依赖的 `verl` 版本
+
+请参阅本目录下的 [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt)（与英文 [`README.md`](README.md) 中说明一致），了解上游仓库、`main` 滚动开发或固定 tag/commit 的安装方式，以及可复制的 `pip` / `git` 命令。
+
 ## 实现细节
 为了在Ascend NPU上实现DeepSeek模型的RL训练，本样例中补充了一些代码，如下所示：
 - 我们参考`verl/utils/reward_score/gsm8k.py`，在`deepscaler.py`中实现了一个简单的规则奖励函数。

--- a/r1_ascend/REQUIRED_VERL.txt
+++ b/r1_ascend/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# r1_ascend — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=r1_ascend
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=6d8d5c129334f40b463dc7e383cf269358352fd6
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- r1_ascend)
+

--- a/rep_exp/README.md
+++ b/rep_exp/README.md
@@ -1,4 +1,8 @@
 <div align="center">
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 # Representation-Based Exploration for Language Models: <br> From Test-Time to Post-Training
 
@@ -10,7 +14,7 @@
 
 Install the following commit of verl:
 ```
-pip install verl@git+https://github.com/volcengine/verl.git@b9bd00efba253ea90072555c45692054cf703de2
+pip install verl@git+https://github.com/verl-project/verl.git@b9bd00efba253ea90072555c45692054cf703de2
 ```
 
 The only other package to install is scikit-learn, which we'll use for applying a sparse projection.

--- a/rep_exp/REQUIRED_VERL.txt
+++ b/rep_exp/REQUIRED_VERL.txt
@@ -1,0 +1,5 @@
+# rep_exp — README pins a specific commit
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_commit
+COMMIT=b9bd00efba253ea90072555c45692054cf703de2
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@b9bd00efba253ea90072555c45692054cf703de2

--- a/retool/README.md
+++ b/retool/README.md
@@ -1,4 +1,9 @@
 # Retool
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 [ReTool: Reinforcement Learning for Strategic Tool Use in LLMs](https://arxiv.org/abs/2504.11536)
 
 ## Overview

--- a/retool/REQUIRED_VERL.txt
+++ b/retool/REQUIRED_VERL.txt
@@ -1,0 +1,6 @@
+# retool — PyPI release pin from recipe README
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_tag
+TAG=v0.6.1
+COMMIT=d62da4950573d7a4b7ef2362337952e7ab59e78d
+PIP_INSTALL=pip install verl==0.6.1

--- a/specRL/histoSpec/README.md
+++ b/specRL/histoSpec/README.md
@@ -1,4 +1,8 @@
 # Accelerating RL Rollout with Model-free Speculative Decoding
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 ## Introduction
 
@@ -35,7 +39,7 @@ sudo apt install -y libprotobuf-dev protobuf-compiler libprotoc-dev \
     libgrpc-dev libgrpc++-dev protobuf-compiler-grpc \
     libxxhash-dev libboost-all-dev cmake
 
-pip install verl@git+https://github.com/volcengine/verl.git@ccd7d934f91be98bb3732c78bd1870fa39c399ad
+pip install verl@git+https://github.com/verl-project/verl.git@ccd7d934f91be98bb3732c78bd1870fa39c399ad
 pip install git+https://github.com/He-Jingkai/specRL.git --no-build-isolation -v
 ```
 

--- a/specRL/histoSpec/REQUIRED_VERL.txt
+++ b/specRL/histoSpec/REQUIRED_VERL.txt
@@ -1,0 +1,5 @@
+# histoSpec — README pins a specific commit
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_commit
+COMMIT=ccd7d934f91be98bb3732c78bd1870fa39c399ad
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@ccd7d934f91be98bb3732c78bd1870fa39c399ad

--- a/spin/README.md
+++ b/spin/README.md
@@ -1,4 +1,8 @@
 # SPIN: Self-Play Fine-Tuning Converts Weak Language Models to Strong Language Models
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 This repository hosts a `verl` recipe inspired by the paper **"Self-Play Fine-Tuning Converts Weak Language Models to Strong Language Models"** (SPIN). SPIN is a language model finetuning algorithm that enables iterative self-improvement through a self-play mechanism inspired by game theory.
 

--- a/spin/REQUIRED_VERL.txt
+++ b/spin/REQUIRED_VERL.txt
@@ -1,0 +1,15 @@
+# SPIN — rolling track + historical baseline tag
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling_with_baseline
+ROLLING_VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+ROLLING_PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+ROLLING_GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=spin
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+REFERENCE_TAG=v0.3.0.post1
+REFERENCE_COMMIT=070ed6ac3f6aea13a916556794f34e8f2bde7dde
+ROLLING_PIP=From repository root: pip install -e ".[sglang]"
+NOTES=Use ROLLING_VERL_COMMIT for the current in-tree workflow; REFERENCE_* is the older documented baseline.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- spin)
+

--- a/spo/README.md
+++ b/spo/README.md
@@ -1,4 +1,8 @@
 # Single-stream Policy Optimization (SPO)
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 [![arXiv](https://img.shields.io/badge/arXiv-2509.13232-b31b1b.svg)](https://arxiv.org/abs/2509.13232)
 [![Python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
@@ -28,7 +32,7 @@
 1. **Clone the VERL repository at the specific commit:**
 
 ```bash
-git clone https://github.com/volcengine/verl.git
+git clone https://github.com/verl-project/verl.git
 cd verl
 git checkout d7944c01e63e9eb639c8357648b7958550591158
 ```

--- a/spo/REQUIRED_VERL.txt
+++ b/spo/REQUIRED_VERL.txt
@@ -1,0 +1,7 @@
+# SPO — README requires this exact commit before pip install -e .
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_commit
+COMMIT=d7944c01e63e9eb639c8357648b7958550591158
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout d7944c01e63e9eb639c8357648b7958550591158
+PIP_INSTALL=pip install -e .
+NOTES=conda environment.yml may list verl==0.7.0.dev0 from an editable install metadata snapshot; trust the git commit above for reproducibility.

--- a/sppo/README.md
+++ b/sppo/README.md
@@ -1,4 +1,8 @@
 # SPPO: Self-Play Preference Optimization for Language Model Alignment
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 This repository hosts the community implementation for the paper [Self-Play Preference Optimization for Language Model Alignment](https://arxiv.org/abs/2405.00675). SPPO can significantly enhance the performance of an LLM without strong external signals such as responses or preferences from GPT-4. It can outperform the model trained with iterative direct preference optimization (DPO), among other methods. SPPO is theoretically grounded, ensuring that the LLM can converge to the von Neumann winner (i.e., Nash equilibrium) under general, potentially intransitive preference, and empirically validated through extensive evaluations on multiple datasets.
 

--- a/sppo/REQUIRED_VERL.txt
+++ b/sppo/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# sppo — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=sppo
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=21892b9276936efab5375c3f6b8415e472ef7118
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- sppo)
+

--- a/swe_agent/README.md
+++ b/swe_agent/README.md
@@ -1,4 +1,8 @@
 # SWE-Agent VERL Recipe
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
 
 Train language models to solve real-world software engineering tasks using reinforcement learning. This recipe integrates [SWE-agent](https://github.com/SWE-agent/SWE-agent) as the agent framework with VERL's GRPO trainer, enabling models to learn from interactive coding feedback in Docker-sandboxed environments.
 

--- a/swe_agent/REQUIRED_VERL.txt
+++ b/swe_agent/REQUIRED_VERL.txt
@@ -1,0 +1,16 @@
+# swe_agent — rolling; exact commits refreshed from this workspace
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=rolling
+BRANCH=main
+# Exact upstream verl commit this file was refreshed against (core library).
+VERL_COMMIT=bcb638649a50e58494a8ddd92085ad1174f674b8
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@bcb638649a50e58494a8ddd92085ad1174f674b8
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout bcb638649a50e58494a8ddd92085ad1174f674b8 && git submodule update --init --recursive recipe
+# Recipe submodule snapshot at the same verl checkout (see `git ls-tree HEAD recipe` in verl).
+RECIPE_SUBMODULE_COMMIT=ba246418f4de12b845a09bba975f1a5242adc898
+RECIPE_FOLDER=swe_agent
+# Latest commit in the recipe repo that touched only this recipe subdirectory.
+RECIPE_FOLDER_LAST_COMMIT=48dd49654f320181595b0a0e9c60df812a1c6eb0
+NOTES=VERL_COMMIT pins the core library; RECIPE_SUBMODULE_COMMIT is the `recipe/` submodule gitlink at that verl revision; RECIPE_FOLDER_LAST_COMMIT narrows to this folder inside the submodule.
+REFRESH=Recompute: (cd verl && git rev-parse HEAD); (cd verl/recipe && git rev-parse HEAD); (cd verl/recipe && git log -1 --format=%H -- swe_agent)
+


### PR DESCRIPTION
Now since the main worker APIs in verl is going to be deprecated and affect many recipes implementation, we directly require that every recipes have a REQUIRED_VERL.txt to emphasize verl version to be used.

This PR find the requirement info from some git history, which may not be proper and precise. So we are calling for help from authors of each recipe to confirm their verl version requirement. Please be free to correct them in this PR or use new PRs to help us make this clearer.

Recipe authors & mantainers , please help confirm `REQUIRED_VERL.txt` / pins

| Recipe | Ping (@GitHub) |
| :-- | :-- |
| `char_count` | @vermouth1992 (inferred — **confirm**) |
| `collabllm` | @Wuyxin · @tongyx361 |
| `dapo` | @tongyx361 · @PeterSH6 |
| `deepeyes` | @Maxwell-Jia · @Visual-Agent |
| `entropy` | @PRIME-RL · @eric-haibin-lin · @PeterSH6 |
| `fapo` | @yyDing1 |
| `fault_recover` | @Li-Yongwen |
| `flash_rl_ascend` | @Nurxat · @yaof20 |
| `flowrl` | @Xuekai-Zhu · @tongyx361 |
| `genrm_remote` | @eric-haibin-lin (**owner TBD**) |
| `gkd/megatron` | @moehanabi · @furunding · **SeptRan** (login TBD) |
| `gvpo` | @jszkc |
| `infigui-g1` | @tongyx361 (**add owner @**) |
| `langgraph_agent` | @glennccc · @WuXibin |
| `minicpmo` | @tongyx361 (**add owner @**) |
| `open_math_reasoning` | @tongyx361 (**add owner @**) |
| `prime` | @KradThed · @tongyx361 · @moehanabi · @furunding |
| `qat` | @alexchiu · @jQizhang · **Zhang Shuai** (@ TBD) |
| `r1` | @eric-haibin-lin · @tongyx361 (**add owners @**) |
| `r1_ascend` | @tongyx361 · **iiiklw** (@ TBD) |
| `rep_exp` | @jtuyls |
| `retool` | @mu-hashmi · @LeoYao123 · @autbuster · @WuXibin |
| `specRL/histoSpec` | @He-Jingkai · @Tianjian-Li |
| `spin` | @cdwang96 · @zhaochenyang20 |
| `spo` | @dzh19990407 · **Zhongwen Xu** (@ TBD) |
| `sppo` | @yhyang201 · @zhaochenyang20 · @tongyx361 · @PeterSH6 · @yifanzhang-pro · @BearBiscuit05 · @ocss884 |
| `swe_agent` | @Mason55 |

Please help review~