### PR TITLE
feat: NeMo Gym vLLM replica

### DIFF
--- a/nemo_gym/README.rst
+++ b/nemo_gym/README.rst
@@ -1,9 +1,11 @@
 NVIDIA NeMo Gym Integration
 ==================================
 
-`NVIDIA NeMo Gym <https://github.com/NVIDIA-NeMo/Gym>`_ is an RL environment framework for
-scalable, multi-environment, and agentic RL. Environments can be tested in NeMo Gym alone before
-training with verl. Visit the `NeMo Gym docs <https://docs.nvidia.com/nemo/gym/latest/index.html>`_
+`NVIDIA NeMo Gym <https://github.com/NVIDIA-NeMo/Gym>`_ is a framework for building training
+and evaluation environment for multi-modal models and agentic systems. It is tested at scale, supports
+multi-environment training, and provides a unified interface for training and evaluation.
+Environments can be tested in NeMo Gym alone before training with verl. 
+Visit the `NeMo Gym docs <https://docs.nvidia.com/nemo/gym/latest/index.html>`_
 to learn more. This recipe demonstrates offline rollout collection, and single and multi-environment 
 training on math and agentic workplace tasks with DAPO.
 
@@ -15,21 +17,33 @@ Local Rollout Collection
 
 **1. Clone repositories**
 
+Clone verl alongside NeMo Gym. The recipe lives in a submodule of verl, so
+``--recurse-submodules`` (or a follow-up ``git submodule update --init``) is required.
+
 .. code-block:: bash
 
-    git clone https://github.com/verl-project/verl.git
+    cd $WORKSPACE  # wherever you want
+    git clone --recurse-submodules https://github.com/verl-project/verl.git
     git clone https://github.com/NVIDIA-NeMo/Gym.git
-    cd Gym
 
-**2. Set up NeMo Gym**
+If you already cloned verl without submodules:
 
 .. code-block:: bash
+
+    cd $WORKSPACE/verl
+    git submodule update --init --recursive
+
+**2. Set up NeMo Gym for local development (note: PyPI installation is also supported)**
+
+.. code-block:: bash
+
+    cd $WORKSPACE/Gym
 
     # Install uv if needed
     curl -LsSf https://astral.sh/uv/install.sh | sh
     source $HOME/.local/bin/env
 
-    export UV_CACHE_DIR=/path/to/cache  # optional, useful on some
+    export UV_CACHE_DIR=/path/to/cache  # optional, useful on shared filesystems
     uv venv --python 3.12
     source .venv/bin/activate
     uv sync --extra dev
@@ -38,16 +52,21 @@ Local Rollout Collection
 
 For standalone testing, point at a local vllm instance (or an endpoint like OpenAI):
 
-.. code-block:: yaml
+.. code-block:: bash
 
-    # env.yaml
+    cd $WORKSPACE/Gym
+    cat > env.yaml <<'EOF'
     policy_base_url: https://localhost:8000/v1
     policy_api_key: empty
     policy_model_name: Qwen/Qwen3-4B-Instruct-2507
+    EOF
 
 **4. Start servers and test an environment**
 
 .. code-block:: bash
+
+    cd $WORKSPACE/Gym
+    source .venv/bin/activate
 
     config_paths="resources_servers/workplace_assistant/configs/workplace_assistant.yaml,\
     responses_api_models/vllm_model/configs/vllm_model.yaml"
@@ -60,6 +79,9 @@ In a separate terminal:
 
 .. code-block:: bash
 
+    cd $WORKSPACE/Gym
+    source .venv/bin/activate
+
     ng_collect_rollouts \
         +agent_name=workplace_assistant_simple_agent \
         +input_jsonl_fpath=resources_servers/workplace_assistant/data/example.jsonl \
@@ -71,6 +93,9 @@ In a separate terminal:
 **6. Prepare training data**
 
 .. code-block:: bash
+
+    cd $WORKSPACE/Gym
+    source .venv/bin/activate
 
     config_paths="resources_servers/workplace_assistant/configs/workplace_assistant.yaml,\
     responses_api_models/vllm_model/configs/vllm_model_for_training.yaml"
@@ -87,15 +112,42 @@ Check that each row has an ``agent_ref`` field. This is required for training.
 Training
 ~~~~~~~~
 
-**7. Launch training**
+**7. Configure paths and secrets**
 
-See ``submit_math.sh``, ``submit_workplace.sh``, or ``submit_multienv.sh`` for Slurm submission examples. The primary arguments relevant to NeMo Gym:
+The submit scripts source a ``config.env`` file for secrets and paths. Copy
+``config.env.example`` and fill in your values:
+
+.. code-block:: bash
+
+    cd $WORKSPACE/verl
+    cp recipe/nemo_gym/config.env.example config.env
+
+.. code-block:: bash
+
+    # edit config.env
+    VERL_ROOT=/path/to/verl
+    NEMO_GYM_ROOT=/path/to/nemo-gym
+    HF_HOME=/path/to/hf_home       # Hugging Face model cache
+    RESULTS_ROOT=/path/to/results  # checkpoints and rollout dumps
+    WANDB_USERNAME=your_username
+    WANDB_API_KEY=your_key
+
+**8. Launch training**
+
+See ``submit_math.sh``, ``submit_workplace.sh``, or ``submit_multienv.sh`` for Slurm submission examples:
+
+.. code-block:: bash
+
+    cd $WORKSPACE/verl
+    sbatch recipe/nemo_gym/submit_workplace.sh
+
+The primary arguments relevant to NeMo Gym:
 
 .. code-block:: bash
 
     +data.custom_cls.path=recipe/nemo_gym/dataset.py
-    +data.custom_cls.name=NemoGymJSONLDataset
-    +actor_rollout_ref.rollout.agent.agent_loop_manager_class=recipe.nemo_gym.agent_loop.NemoGymAgentLoopManager
+    +data.custom_cls.name=NeMoGymJSONLDataset
+    +actor_rollout_ref.rollout.agent.agent_loop_manager_class=recipe.nemo_gym.agent_loop.NeMoGymAgentLoopManager
     +actor_rollout_ref.rollout.agent.agent_loop_config_path=/path/to/configs/workplace.yaml
 
 Multi-Environment Training
@@ -128,42 +180,12 @@ to its environment via the ``agent_ref`` field.
 Note that some NeMo Gym environments such as SWE-RL launch containers and may require additional
 setup (e.g. Apptainer). See each environment's README in the NeMo Gym repo for details.
 
-Overview
---------
-
-- ``agent_loop.py`` — ``NemoGymAgentLoopManager``: wraps NeMo Gym's rollout collection interface
-  to collect rollouts for input tasks. Converts results to verl's DataProto format.
-- ``dataset.py`` — ``NemoGymJSONLDataset``: loads NeMo Gym JSONL datasets.
-- ``server_patch.py`` — patches vLLM's ``OpenAIServingChat`` and ``OpenAIServingTokenization``
-  to correct for retokenization errors in multi-step rollouts, matching NeMo RL's approach.
-  **Tested with vLLM 0.17.0** (``verlai/verl:vllm017.latest``). The ``_preprocess_chat`` return
-  structure may change between vLLM versions — see comment in ``server_patch.py``.
-
 Requirements
 ------------
 
 - A NeMo Gym clone (0.2.1+) with the environments you want to train on.
 - ``pip install -e $NEMO_GYM_ROOT`` in the container at job start. ``pip install nemo-gym`` also works if you don't need to modify environments. Pin to ``nemo-gym==0.2.1`` if you run into any issues on newer versions.
 - Container: ``verlai/verl:vllm017.latest`` (vLLM 0.17.0).
-
-Environment Variables
----------------------
-
-The submit scripts source a ``config.env`` file for secrets and paths. Copy
-``config.env.example`` and fill in your values:
-
-.. code-block:: bash
-
-    cp recipe/nemo_gym/config.env.example config.env
-
-.. code-block:: bash
-
-    VERL_ROOT=/path/to/verl
-    NEMO_GYM_ROOT=/path/to/nemo-gym
-    HF_HOME=/path/to/hf_home       # Hugging Face model cache
-    RESULTS_ROOT=/path/to/results  # checkpoints and rollout dumps
-    WANDB_USERNAME=your_username
-    WANDB_API_KEY=your_key
 
 Config YAML
 -----------
@@ -178,3 +200,24 @@ Each training run needs a config YAML (see ``configs/math.yaml`` for an example)
       config_paths:
         - $NEMO_GYM_ROOT/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
         - $NEMO_GYM_ROOT/resources_servers/your_env/configs/your_env.yaml
+
+Implementation Details
+----------------------
+
+- ``agent_loop.py`` — ``NeMoGymAgentLoopManager``: wraps NeMo Gym's rollout collection interface
+  to collect rollouts for input tasks. Converts results to verl's DataProto format.
+- ``dataset.py`` — ``NeMoGymJSONLDataset``: loads NeMo Gym JSONL datasets.
+- ``replica.py`` — ``NeMoGymvLLMReplica`` / ``NeMoGymvLLMHttpServer``: verl vLLM server subclass
+  that applies the patches in ``server_patch.py`` on server startup. Only instantiated when
+  ``NeMoGymAgentLoopManager`` is the active agent-loop manager, so non-recipe users are unaffected.
+- ``server_patch.py`` — two monkey patches applied by ``NeMoGymvLLMHttpServer``:
+
+  - ``patch_serving_chat_for_nemo_gym()`` — patches vLLM's ``OpenAIServingChat`` and
+    ``OpenAIServingTokenization`` to splice original token IDs back into the tokenized prompt,
+    preventing retokenization drift in multi-step rollouts (matches NeMo RL's approach).
+  - ``patch_hermes_tool_parser_thread_safety()`` — caches the tokenizer encode/decode results
+    in ``Hermes2ProToolParser.__init__`` so concurrent requests don't race the Rust tokenizer
+    and crash with ``RuntimeError: Already borrowed``. Based on prime-rl PR #1837.
+
+  **Tested with vLLM 0.17.0** (``verlai/verl:vllm017.latest``). The ``_preprocess_chat`` return
+  structure may change between vLLM versions — see comment in ``server_patch.py``.

--- a/nemo_gym/README.rst
+++ b/nemo_gym/README.rst
@@ -142,8 +142,8 @@ Overview
 Requirements
 ------------
 
-- A NeMo Gym clone with the environments you want to train on.
-- ``pip install -e /path/to/nemo-gym`` in the container at job start.
+- A NeMo Gym clone (0.2.1+) with the environments you want to train on.
+- ``pip install -e $NEMO_GYM_ROOT`` in the container at job start. ``pip install nemo-gym`` also works if you don't need to modify environments. Pin to ``nemo-gym==0.2.1`` if you run into any issues on newer versions.
 - Container: ``verlai/verl:vllm017.latest`` (vLLM 0.17.0).
 
 Environment Variables
@@ -173,8 +173,8 @@ Each training run needs a config YAML (see ``configs/math.yaml`` for an example)
 .. code-block:: yaml
 
     nemo_gym:
-      nemo_gym_root: $NEMO_GYM_ROOT        # path to NeMo Gym clone, expanded at runtime
-      uses_reasoning_parser: false          # set true for reasoning models (e.g. DeepSeek-R1)
+      nemo_gym_root: $NEMO_GYM_ROOT
+      uses_reasoning_parser: false          # set true for reasoning models
       config_paths:
         - $NEMO_GYM_ROOT/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
         - $NEMO_GYM_ROOT/resources_servers/your_env/configs/your_env.yaml

--- a/nemo_gym/agent_loop.py
+++ b/nemo_gym/agent_loop.py
@@ -15,12 +15,15 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util as _ilu
+import logging
 import os
 import socket
 import sys
 import threading
 from collections import defaultdict
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # TODO: remove in next nemo gym release
 _nemo_gym_path = os.environ.get("NEMO_GYM_ROOT")
@@ -182,7 +185,7 @@ class NeMoGymAgentLoopManager(AgentLoopManager):
         )
         self._rollout_thread.start()
 
-        print(f"NeMoGymAgentLoopManager ready: {len(base_urls)} vLLM endpoints: {base_urls}")
+        logger.info(f"NeMoGymAgentLoopManager ready: {len(base_urls)} vLLM endpoints: {base_urls}")
 
     def generate_sequences(self, prompts: DataProto) -> DataProto:
         future = asyncio.run_coroutine_threadsafe(self._async_generate_sequences(prompts), self._rollout_loop)

--- a/nemo_gym/agent_loop.py
+++ b/nemo_gym/agent_loop.py
@@ -58,6 +58,12 @@ _postprocess = _AgentLoopWorker._postprocess
 
 
 class NemoGymAgentLoopManager(AgentLoopManager):
+    def __init__(self, *args, **kwargs):
+        from recipe.nemo_gym.replica import NemoGymVLLMReplica
+
+        self.rollout_replica_class = NemoGymVLLMReplica
+        super().__init__(*args, **kwargs)
+
     @classmethod
     @auto_await
     async def create(

--- a/nemo_gym/agent_loop.py
+++ b/nemo_gym/agent_loop.py
@@ -57,11 +57,11 @@ from verl.utils.ray_utils import auto_await
 _postprocess = _AgentLoopWorker._postprocess
 
 
-class NemoGymAgentLoopManager(AgentLoopManager):
+class NeMoGymAgentLoopManager(AgentLoopManager):
     def __init__(self, *args, **kwargs):
-        from recipe.nemo_gym.replica import NemoGymVLLMReplica
+        from recipe.nemo_gym.replica import NeMoGymvLLMReplica
 
-        self.rollout_replica_class = NemoGymVLLMReplica
+        self.rollout_replica_class = NeMoGymvLLMReplica
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -73,7 +73,7 @@ class NemoGymAgentLoopManager(AgentLoopManager):
         rollout_resource_pool=None,
         reward_loop_worker_handles=None,
         teacher_model_manager=None,
-    ) -> NemoGymAgentLoopManager:
+    ) -> NeMoGymAgentLoopManager:
         instance = cls(
             config,
             worker_group,
@@ -182,7 +182,7 @@ class NemoGymAgentLoopManager(AgentLoopManager):
         )
         self._rollout_thread.start()
 
-        print(f"NemoGymAgentLoopManager ready: {len(base_urls)} vLLM endpoints: {base_urls}")
+        print(f"NeMoGymAgentLoopManager ready: {len(base_urls)} vLLM endpoints: {base_urls}")
 
     def generate_sequences(self, prompts: DataProto) -> DataProto:
         future = asyncio.run_coroutine_threadsafe(self._async_generate_sequences(prompts), self._rollout_loop)

--- a/nemo_gym/config.env.example
+++ b/nemo_gym/config.env.example
@@ -1,6 +1,6 @@
 VERL_ROOT=/path/to/verl
 NEMO_GYM_ROOT=/path/to/nemo-gym
 HF_HOME=/path/to/hf_home       # Hugging Face model cache
-RESULTS_ROOT=/path/to/results   # checkpoints and rollout dumps
+RESULTS_ROOT=/path/to/results  # checkpoints and rollout dumps
 WANDB_USERNAME=your_wandb_username
 WANDB_API_KEY=your_key_here

--- a/nemo_gym/dataset.py
+++ b/nemo_gym/dataset.py
@@ -18,7 +18,7 @@ import torch
 from torch.utils.data import Dataset
 
 
-class NemoGymJSONLDataset(Dataset):
+class NeMoGymJSONLDataset(Dataset):
     def __init__(
         self,
         data_files: str | list[str],
@@ -36,7 +36,7 @@ class NemoGymJSONLDataset(Dataset):
         for path in data_files:
             path = Path(path)
             if not path.exists():
-                raise FileNotFoundError(f"NemoGymJSONLDataset: file not found: {path}")
+                raise FileNotFoundError(f"NeMoGymJSONLDataset: file not found: {path}")
             with open(path) as f:
                 for line in f:
                     line = line.strip()

--- a/nemo_gym/replica.py
+++ b/nemo_gym/replica.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ray
+
+from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer, vLLMReplica
+
+
+class NemoGymVLLMHttpServer(vLLMHttpServer):
+    def apply_nemo_gym_server_patch(self):
+        from recipe.nemo_gym.server_patch import patch_serving_chat_for_nemo_gym
+
+        patch_serving_chat_for_nemo_gym()
+
+
+class NemoGymVLLMReplica(vLLMReplica):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.server_class = ray.remote(NemoGymVLLMHttpServer)

--- a/nemo_gym/replica.py
+++ b/nemo_gym/replica.py
@@ -16,14 +16,18 @@ import ray
 from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer, vLLMReplica
 
 
-class NemoGymVLLMHttpServer(vLLMHttpServer):
+class NeMoGymvLLMHttpServer(vLLMHttpServer):
     def apply_nemo_gym_server_patch(self):
-        from recipe.nemo_gym.server_patch import patch_serving_chat_for_nemo_gym
+        from recipe.nemo_gym.server_patch import (
+            patch_hermes_tool_parser_thread_safety,
+            patch_serving_chat_for_nemo_gym,
+        )
 
         patch_serving_chat_for_nemo_gym()
+        patch_hermes_tool_parser_thread_safety()
 
 
-class NemoGymVLLMReplica(vLLMReplica):
+class NeMoGymvLLMReplica(vLLMReplica):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.server_class = ray.remote(NemoGymVLLMHttpServer)
+        self.server_class = ray.remote(NeMoGymvLLMHttpServer)

--- a/nemo_gym/server_patch.py
+++ b/nemo_gym/server_patch.py
@@ -126,3 +126,71 @@ def patch_serving_chat_for_nemo_gym() -> None:
     for cls in (OpenAIServingChat, OpenAIServingTokenization):
         cls._preprocess_chat = _make_patched_preprocess_chat(cls._preprocess_chat)
         logger.warning(f"[nemo-gym] applied retokenization patch to {cls.__name__}.")
+
+
+def patch_hermes_tool_parser_thread_safety() -> None:
+    """Cache tokenizer encode/decode results in Hermes2ProToolParser.__init__
+    so concurrent instantiations don't race the Rust tokenizer and crash with
+    ``RuntimeError: Already borrowed``. First call under lock runs the original
+    __init__; subsequent calls for the same tokenizer reuse the cached token IDs.
+    Based on prime-rl PR #1837.
+    """
+    import threading
+
+    import regex as re
+
+    try:
+        from vllm.tool_parsers.abstract_tool_parser import ToolParser
+        from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+    except ImportError:
+        from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import ToolParser
+        from vllm.entrypoints.openai.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+
+    _original_init = Hermes2ProToolParser.__init__
+    _cache: dict[int, dict] = {}
+    _lock = threading.Lock()
+
+    def _patched_init(self, tokenizer):
+        try:
+            from vllm.transformers_utils.tokenizer import MistralTokenizer
+
+            actual_tokenizer = tokenizer.tokenizer if isinstance(tokenizer, MistralTokenizer) else tokenizer
+        except ImportError:
+            actual_tokenizer = tokenizer
+            MistralTokenizer = None  # noqa: N806
+
+        key = id(actual_tokenizer)
+        if key in _cache:
+            ToolParser.__init__(self, tokenizer)
+            if MistralTokenizer is not None and isinstance(tokenizer, MistralTokenizer):
+                self.model_tokenizer = tokenizer.tokenizer
+            self.current_tool_name_sent = False
+            self.prev_tool_call_arr = []
+            self.current_tool_id = -1
+            self.streamed_args_for_tool = []
+            self.tool_call_start_token = "<tool_call>"
+            self.tool_call_end_token = "</tool_call>"
+            self.tool_call_regex = re.compile(r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)", re.DOTALL)
+            self.scratch_pad_regex = re.compile(r"<scratch_pad>(.*?)</scratch_pad>", re.DOTALL)
+            cached = _cache[key]
+            self.tool_call_start_token_ids = cached["start_ids"]
+            self.tool_call_end_token_ids = cached["end_ids"]
+            self.tool_call_start_token_array = cached["start_array"]
+            self.tool_call_end_token_array = cached["end_array"]
+            self.buffered_delta_text = ""
+            return
+
+        with _lock:
+            if key in _cache:
+                _patched_init(self, tokenizer)
+                return
+            _original_init(self, tokenizer)
+            _cache[key] = {
+                "start_ids": self.tool_call_start_token_ids,
+                "end_ids": self.tool_call_end_token_ids,
+                "start_array": self.tool_call_start_token_array,
+                "end_array": self.tool_call_end_token_array,
+            }
+
+    Hermes2ProToolParser.__init__ = _patched_init
+    logger.warning("[nemo-gym] applied hermes tool parser thread-safety patch.")

--- a/nemo_gym/server_patch.py
+++ b/nemo_gym/server_patch.py
@@ -133,37 +133,27 @@ def patch_hermes_tool_parser_thread_safety() -> None:
     so concurrent instantiations don't race the Rust tokenizer and crash with
     ``RuntimeError: Already borrowed``. First call under lock runs the original
     __init__; subsequent calls for the same tokenizer reuse the cached token IDs.
-    Based on prime-rl PR #1837. 
+    Based on prime-rl PR #1837.
     Related vLLM PRs: #37169, #37382, #40059, or #35034 and vLLM issue: #34932
     """
+    import re
     import threading
 
-    import regex as re
-
-    try:
-        from vllm.tool_parsers.abstract_tool_parser import ToolParser
-        from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
-    except ImportError:
-        from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import ToolParser
-        from vllm.entrypoints.openai.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+    # vLLM 0.17.0 module paths
+    from vllm.tool_parsers.abstract_tool_parser import ToolParser
+    from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+    from vllm.transformers_utils.tokenizer import MistralTokenizer
 
     _original_init = Hermes2ProToolParser.__init__
     _cache: dict[int, dict] = {}
     _lock = threading.Lock()
 
     def _patched_init(self, tokenizer):
-        try:
-            from vllm.transformers_utils.tokenizer import MistralTokenizer
-
-            actual_tokenizer = tokenizer.tokenizer if isinstance(tokenizer, MistralTokenizer) else tokenizer
-        except ImportError:
-            actual_tokenizer = tokenizer
-            MistralTokenizer = None  # noqa: N806
-
+        actual_tokenizer = tokenizer.tokenizer if isinstance(tokenizer, MistralTokenizer) else tokenizer
         key = id(actual_tokenizer)
         if key in _cache:
             ToolParser.__init__(self, tokenizer)
-            if MistralTokenizer is not None and isinstance(tokenizer, MistralTokenizer):
+            if isinstance(tokenizer, MistralTokenizer):
                 self.model_tokenizer = tokenizer.tokenizer
             self.current_tool_name_sent = False
             self.prev_tool_call_arr = []

--- a/nemo_gym/server_patch.py
+++ b/nemo_gym/server_patch.py
@@ -133,7 +133,8 @@ def patch_hermes_tool_parser_thread_safety() -> None:
     so concurrent instantiations don't race the Rust tokenizer and crash with
     ``RuntimeError: Already borrowed``. First call under lock runs the original
     __init__; subsequent calls for the same tokenizer reuse the cached token IDs.
-    Based on prime-rl PR #1837.
+    Based on prime-rl PR #1837. 
+    Related vLLM PRs: #37169, #37382, #40059, or #35034 and vLLM issue: #34932
     """
     import threading
 

--- a/nemo_gym/server_patch.py
+++ b/nemo_gym/server_patch.py
@@ -142,13 +142,14 @@ def patch_hermes_tool_parser_thread_safety() -> None:
     # vLLM 0.17.0 module paths
     from vllm.tool_parsers.abstract_tool_parser import ToolParser
     from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
-    from vllm.transformers_utils.tokenizer import MistralTokenizer
 
     _original_init = Hermes2ProToolParser.__init__
     _cache: dict[int, dict] = {}
     _lock = threading.Lock()
 
     def _patched_init(self, tokenizer):
+        from vllm.tokenizers.mistral import MistralTokenizer
+
         actual_tokenizer = tokenizer.tokenizer if isinstance(tokenizer, MistralTokenizer) else tokenizer
         key = id(actual_tokenizer)
         if key in _cache:

--- a/nemo_gym/submit_math.sh
+++ b/nemo_gym/submit_math.sh
@@ -76,7 +76,7 @@ echo "Installing nemo-gym..."
 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
     --no-container-mount-home --container-mounts=${MOUNTS} \
     --container-name=ray-head \
-    bash -c "touch ${NEMO_GYM_ROOT}/scripts/__init__.py && pip install -q uv && echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
+    bash -c "echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q uv && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
 
 echo "Launching training on ${head_node}..."
 PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
@@ -91,7 +91,7 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
         VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         TORCH_NCCL_AVOID_RECORD_STREAMS=1 \
         NEMO_GYM_ROOT="${NEMO_GYM_ROOT}" \
-        PYTHONPATH="${NEMO_GYM_ROOT}:${VERL_ROOT}" \
+        PYTHONPATH="${VERL_ROOT}" \
         RAY_grpc_keepalive_time_ms=60000 \
         RAY_grpc_keepalive_timeout_ms=600000 \
         RAY_grpc_client_keepalive_time_ms=60000 \

--- a/nemo_gym/submit_math.sh
+++ b/nemo_gym/submit_math.sh
@@ -17,8 +17,8 @@ GPUS_PER_NODE=8
 source "${SLURM_SUBMIT_DIR}/config.env"
 
 MODEL_PATH="/path/to/Qwen3-4B-Instruct"
-TRAIN_FILE="/path/to/math_with_judge/dapo17k_bytedtsinghua_train_nrl.jsonl"
-TEST_FILE="/path/to/math_with_judge/aime24_bytedtsinghua_validation_nrl.jsonl"
+TRAIN_FILE="/path/to/math_with_judge/dapo17k_bytedtsinghua_train.jsonl"
+TEST_FILE="/path/to/math_with_judge/aime24_bytedtsinghua_validation.jsonl"
 CKPTS_DIR="${RESULTS_ROOT}/DAPO-Qwen2.5-7b-MATH-megatron"
 
 CONTAINER="verlai/verl:vllm017.latest"
@@ -102,7 +102,7 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
             data.train_files="${TRAIN_FILE}" \
             data.val_files="${TEST_FILE}" \
             +data.custom_cls.path="${VERL_ROOT}/recipe/nemo_gym/dataset.py" \
-            +data.custom_cls.name=NemoGymJSONLDataset \
+            +data.custom_cls.name=NeMoGymJSONLDataset \
             data.truncation=left \
             data.train_batch_size=32 \
             actor_rollout_ref.rollout.n=16 \
@@ -161,6 +161,6 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
             trainer.default_local_dir="${CKPTS_DIR}" \
             trainer.resume_mode=disable \
             trainer.log_val_generations=10 \
-            +actor_rollout_ref.rollout.agent.agent_loop_manager_class='recipe.nemo_gym.agent_loop.NemoGymAgentLoopManager' \
+            +actor_rollout_ref.rollout.agent.agent_loop_manager_class='recipe.nemo_gym.agent_loop.NeMoGymAgentLoopManager' \
             +actor_rollout_ref.rollout.agent.agent_loop_config_path="${VERL_ROOT}/recipe/nemo_gym/configs/math.yaml" \
     2>&1

--- a/nemo_gym/submit_multienv.sh
+++ b/nemo_gym/submit_multienv.sh
@@ -83,8 +83,6 @@ srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
     --container-name=ray-head \
     bash -c "echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q uv && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
 
-# TODO: test if hermes tool parser still hits "already borrowed" tokenizer errors under concurrent load
-# if so, point to or provide the patch here, or use a different model+tool parser
 
 echo "Launching training on ${head_node}..."
 PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
@@ -110,7 +108,7 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
             data.train_files="${TRAIN_FILE}" \
             data.val_files="${TEST_FILE}" \
             +data.custom_cls.path="${VERL_ROOT}/recipe/nemo_gym/dataset.py" \
-            +data.custom_cls.name=NemoGymJSONLDataset \
+            +data.custom_cls.name=NeMoGymJSONLDataset \
             data.truncation=left \
             data.train_batch_size=32 \
             actor_rollout_ref.rollout.n=16 \
@@ -152,7 +150,7 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
             actor_rollout_ref.rollout.val_kwargs.n=1 \
             actor_rollout_ref.rollout.name=vllm \
             '+actor_rollout_ref.rollout.engine_kwargs.vllm.enable-auto-tool-choice=true' \
-            '+actor_rollout_ref.rollout.engine_kwargs.vllm.tool-call-parser=hermes'  \
+            '+actor_rollout_ref.rollout.engine_kwargs.vllm.tool-call-parser=hermes' \
             '+actor_rollout_ref.rollout.engine_kwargs.vllm.max-model-len=32768' \
             actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=2 \
             actor_rollout_ref.ref.megatron.tensor_model_parallel_size=4 \
@@ -172,6 +170,6 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
             trainer.resume_mode=disable \
             trainer.log_val_generations=10 \
             +trainer.rollout_data_dir="${ROLLOUT_DIR}" \
-            +actor_rollout_ref.rollout.agent.agent_loop_manager_class='recipe.nemo_gym.agent_loop.NemoGymAgentLoopManager' \
+            +actor_rollout_ref.rollout.agent.agent_loop_manager_class='recipe.nemo_gym.agent_loop.NeMoGymAgentLoopManager' \
             +actor_rollout_ref.rollout.agent.agent_loop_config_path="${VERL_ROOT}/recipe/nemo_gym/configs/multienv.yaml" \
     2>&1

--- a/nemo_gym/submit_multienv.sh
+++ b/nemo_gym/submit_multienv.sh
@@ -41,8 +41,7 @@ SRUN_ARGS="--no-container-mount-home --container-image=${CONTAINER} --container-
 echo "Starting Ray head on ${head_node}..."
 srun --nodes=1 --ntasks=1 -w "${head_node}" ${SRUN_ARGS} --container-name=ray-head \
     env -u ROCR_VISIBLE_DEVICES WANDB_API_KEY="${WANDB_API_KEY}" \
-        NEMO_GYM_ROOT="${NEMO_GYM_ROOT}" \
-        PYTHONPATH="${NEMO_GYM_ROOT}:${VERL_ROOT}" \
+        PYTHONPATH="${VERL_ROOT}" \
     ray start --head \
         --node-ip-address="${head_node_ip}" \
         --port=${RAY_PORT} \
@@ -56,8 +55,7 @@ for ((i = 1; i <= worker_num; i++)); do
     echo "Starting Ray worker ${i} on ${node_i}..."
     srun --nodes=1 --ntasks=1 -w "${node_i}" ${SRUN_ARGS} \
         env -u ROCR_VISIBLE_DEVICES WANDB_API_KEY="${WANDB_API_KEY}" \
-            NEMO_GYM_ROOT="${NEMO_GYM_ROOT}" \
-            PYTHONPATH="${NEMO_GYM_ROOT}:${VERL_ROOT}" \
+            PYTHONPATH="${VERL_ROOT}" \
         ray start \
             --address="${ip_head}" \
             --num-gpus="${GPUS_PER_NODE}" \
@@ -83,7 +81,7 @@ echo "Installing nemo-gym..."
 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
     --no-container-mount-home --container-mounts=${MOUNTS} \
     --container-name=ray-head \
-    bash -c "PYTHONPATH= touch ${NEMO_GYM_ROOT}/scripts/__init__.py && pip install -q uv && echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
+    bash -c "echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q uv && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
 
 # TODO: test if hermes tool parser still hits "already borrowed" tokenizer errors under concurrent load
 # if so, point to or provide the patch here, or use a different model+tool parser
@@ -100,7 +98,7 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
         VLLM_USE_V1=1 \
         TORCH_NCCL_AVOID_RECORD_STREAMS=1 \
         NEMO_GYM_ROOT="${NEMO_GYM_ROOT}" \
-        PYTHONPATH="${NEMO_GYM_ROOT}:${VERL_ROOT}" \
+        PYTHONPATH="${VERL_ROOT}" \
         VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         RAY_grpc_keepalive_time_ms=60000 \
         RAY_grpc_keepalive_timeout_ms=600000 \

--- a/nemo_gym/submit_workplace.sh
+++ b/nemo_gym/submit_workplace.sh
@@ -76,7 +76,7 @@ echo "Installing nemo-gym..."
 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
     --no-container-mount-home --container-mounts=${MOUNTS} \
     --container-name=ray-head \
-    bash -c "PYTHONPATH= touch ${NEMO_GYM_ROOT}/scripts/__init__.py && pip install -q uv && echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
+    bash -c "echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q uv && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
 
 # TODO: test if hermes tool parser still hits "already borrowed" tokenizer errors under concurrent load
 # if so, point to or provide the patch here, or use a different model+tool parser
@@ -93,7 +93,7 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
         VLLM_USE_V1=1 \
         TORCH_NCCL_AVOID_RECORD_STREAMS=1 \
         NEMO_GYM_ROOT="${NEMO_GYM_ROOT}" \
-        PYTHONPATH="${NEMO_GYM_ROOT}:${VERL_ROOT}" \
+        PYTHONPATH="${VERL_ROOT}" \
         VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         RAY_grpc_keepalive_time_ms=60000 \
         RAY_grpc_keepalive_timeout_ms=600000 \

--- a/nemo_gym/submit_workplace.sh
+++ b/nemo_gym/submit_workplace.sh
@@ -78,8 +78,6 @@ srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
     --container-name=ray-head \
     bash -c "echo 'blinker==1.4' > /tmp/constraints.txt && pip install -q uv && pip install -q -e ${NEMO_GYM_ROOT} -c /tmp/constraints.txt"
 
-# TODO: test if hermes tool parser still hits "already borrowed" tokenizer errors under concurrent load
-# if so, point to or provide the patch here, or use a different model+tool parser
 
 echo "Launching training on ${head_node}..."
 PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
@@ -105,7 +103,7 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
             data.train_files="${TRAIN_FILE}" \
             data.val_files="${TEST_FILE}" \
             +data.custom_cls.path="${VERL_ROOT}/recipe/nemo_gym/dataset.py" \
-            +data.custom_cls.name=NemoGymJSONLDataset \
+            +data.custom_cls.name=NeMoGymJSONLDataset \
             data.truncation=left \
             data.train_batch_size=32 \
             actor_rollout_ref.rollout.n=16 \
@@ -166,6 +164,6 @@ PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${head_node}" \
             trainer.default_local_dir="${CKPTS_DIR}" \
             trainer.resume_mode=disable \
             trainer.log_val_generations=10 \
-            +actor_rollout_ref.rollout.agent.agent_loop_manager_class='recipe.nemo_gym.agent_loop.NemoGymAgentLoopManager' \
+            +actor_rollout_ref.rollout.agent.agent_loop_manager_class='recipe.nemo_gym.agent_loop.NeMoGymAgentLoopManager' \
             +actor_rollout_ref.rollout.agent.agent_loop_config_path="${VERL_ROOT}/recipe/nemo_gym/configs/workplace.yaml" \
     2>&1


### PR DESCRIPTION
moves server side retokenization correction patch to vllm replica instead of verl-core, which is mirrored from NeMo RL for on-policy token in token out training

also hermes tool parser patch based on prime-rl merged PR #1837 
(see also vllm open PRs: #37169, #37382, #40059, or #35034 and issue #34932)

also some docs and renaming 