### PR TITLE
feat: add randopt algorithm

### DIFF
--- a/randopt/README.md
+++ b/randopt/README.md
@@ -1,0 +1,115 @@
+# RandOpt
+
+## Required `verl` Version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode, and copy-pastable `pip` instruction.
+
+## Overview
+
+RandOpt is a LLM post-training algorithm introduced in [**Neural Thickets: Diverse Task Experts Are Dense Around Pretrained Weights**](https://arxiv.org/abs/2603.12228) (ICML 2026 Spotlight). It samples Gaussian perturbations around a pretrained model, evaluates the perturbed models in parallel with vLLM, selects the top-performing perturbations, and evaluates them with majority-vote ensembling.
+
+Project page: <https://thickets.mit.edu>
+
+## Installation
+
+Install the pinned `verl` version and runtime dependencies:
+
+```bash
+pip install verl==0.7.1
+pip install vllm ray pandas pyarrow tqdm
+```
+
+If running from a `verl` checkout, initialize the recipe submodule first:
+
+```bash
+git submodule update --init --recursive recipe
+```
+
+## Run
+
+Run the Countdown example from the `verl` repository root. The following command expects prepared Countdown parquet files:
+
+```bash
+python3 -m recipe.randopt.main_randopt \
+    model.path=Qwen/Qwen2.5-3B-Instruct \
+    data.task_type=countdown \
+    data.train_files=data/countdown/train.parquet \
+    data.val_files=data/countdown/test.parquet \
+    randopt.worker_extension_cls=recipe.randopt.worker_extension.WorkerExtension
+```
+
+For a quick test with generated toy Countdown data:
+
+```bash
+python3 -m recipe.randopt.run_countdown_example
+```
+
+Common overrides:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 python3 -m recipe.randopt.main_randopt \
+    model.path=Qwen/Qwen2.5-7B-Instruct \
+    data.task_type=countdown \
+    data.train_files=/path/to/train.parquet \
+    data.val_files=/path/to/test.parquet \
+    randopt.num_engines=4 \
+    randopt.tensor_parallel_size=1 \
+    "randopt.sigma_list=[0.0005,0.001,0.002]" \
+    "randopt.top_k_ratios=[0.02,0.1]" \
+    randopt.worker_extension_cls=recipe.randopt.worker_extension.WorkerExtension \
+    trainer.n_gpus_per_node=4
+```
+
+
+If you are running from the standalone `verl-recipe` repository root instead of from `verl`, drop the `recipe.` prefix:
+
+```bash
+python3 -m randopt.run_countdown_example
+python3 -m randopt.main_randopt ...
+```
+
+## Test Result
+
+The following test was run on six H200 GPUs with `Qwen/Qwen2.5-1.5B-Instruct`, `population_size=500`, 20 toy Countdown training examples, 200 validation examples, and one RandOpt iteration:
+
+```text
+train/reward_mean: 0.1045
+train/reward_std: 0.0664
+train/reward_min: 0.0130
+train/reward_max: 0.3820
+ensemble/top_10_accuracy: 42.0%
+ensemble/top_50_accuracy: 64.0%
+```
+
+With `top_k_ratios=[0.02,0.1]`, `population_size=500` evaluates top-10 and top-50 majority-vote ensembles. The base model may score poorly on the toy Countdown examples, but the ensemble metrics should still be emitted at the end of a successful smoke test run.
+
+## Custom Tasks
+
+For a custom dataset, set `data.task_type=custom` and provide a reward function and optional prompt processor:
+
+```bash
+python3 -m recipe.randopt.main_randopt \
+    data.task_type=custom \
+    data.train_files=/path/to/train.parquet \
+    data.val_files=/path/to/test.parquet \
+    data.reward_fn_path=/path/to/reward.py \
+    data.reward_fn_name=my_reward_fn \
+    data.prompt_processor_path=/path/to/prompts.py \
+    data.prompt_processor_name=my_prompt_processor
+```
+
+The reward function should accept `(response: str, task_data: dict)` and return either a float or a dict with a `reward` field.
+
+## Citation
+
+```bibtex
+@misc{gan2026neuralthickets,
+      title={Neural Thickets: Diverse Task Experts Are Dense Around Pretrained Weights},
+      author={Yulu Gan and Phillip Isola},
+      year={2026},
+      eprint={2603.12228},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2603.12228},
+}
+```

--- a/randopt/REQUIRED_VERL.txt
+++ b/randopt/REQUIRED_VERL.txt
@@ -1,0 +1,7 @@
+# RandOpt recipe is prepared against the latest tested verl release line.
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_tag
+TAG=v0.7.1
+COMMIT=bec9ef74768dd201881cd4e54cd0385e87caae27
+PIP_INSTALL=pip install verl==0.7.1
+

--- a/randopt/__init__.py
+++ b/randopt/__init__.py
@@ -1,0 +1,1 @@
+"""RandOpt recipe for zeroth-order post-training with verl and vLLM."""

--- a/randopt/config/randopt_trainer.yaml
+++ b/randopt/config/randopt_trainer.yaml
@@ -1,0 +1,66 @@
+# RandOpt recipe configuration.
+
+randopt:
+  sigma: 0.001
+  # Optional list of perturbation scales. When set, each sampled perturbation
+  # draws one sigma uniformly from this list, following the reference RandOpt code.
+  sigma_list: null
+  population_size: 30
+  # Evaluate majority-vote ensembles for top int(ratio * population_size) perturbations.
+  top_k_ratios:
+    - 0.02
+    - 0.1
+  # Optional absolute K values. When set, this takes precedence over top_k_ratios.
+  top_k_values: null
+  num_engines: 4
+  tensor_parallel_size: 1
+  precision: bfloat16
+  max_tokens: 1024
+  temperature: 0.0
+  gpu_memory_utilization: 0.85
+  enable_prefix_caching: false
+  enforce_eager: true
+  worker_extension_cls: recipe.randopt.worker_extension.WorkerExtension
+  global_seed: 42
+  debug_print_samples: false
+  debug_max_samples: 4
+
+model:
+  path: Qwen/Qwen2.5-3B-Instruct
+  trust_remote_code: false
+
+data:
+  # Built-in options: countdown, parquet_prompt, custom.
+  task_type: countdown
+  train_files: data/countdown/train.parquet
+  val_files: data/countdown/test.parquet
+  train_max_samples: 200
+  val_max_samples: -1
+  system_message: "You are a helpful assistant. You first think about the reasoning process in your mind and then provide the user with the answer."
+  user_template: "Using the numbers {numbers}, create an equation that equals {target}. You can use basic arithmetic operations (+, -, *, /) and each number can only be used once. Show your work in <think> </think> tags. Return the final answer in <answer> </answer> tags, for example <answer> (1 + 2) / 3 </answer>."
+  response_prompt: "Let me solve this step by step.\n<think>"
+  reward_fn_path: null
+  reward_fn_name: null
+  prompt_processor_path: null
+  prompt_processor_name: null
+
+trainer:
+  project_name: randopt
+  experiment_name: countdown-randopt
+  logger:
+    - console
+  default_local_dir: /tmp/${oc.env:USER}/verl/randopt_checkpoints
+  default_hdfs_dir: null
+  device: cuda
+  n_gpus_per_node: 4
+  nnodes: 1
+  total_epochs: null
+  test_freq: null
+  save_freq: -1
+  npu_profile:
+    enable: false
+
+ray_kwargs:
+  ray_init:
+    runtime_env: {}
+

--- a/randopt/main_randopt.py
+++ b/randopt/main_randopt.py
@@ -1,0 +1,80 @@
+import os
+import socket
+import tempfile
+import time
+from pprint import pprint
+
+import hydra
+import ray
+from omegaconf import OmegaConf
+from transformers import AutoTokenizer
+
+from verl.utils.device import auto_set_device
+
+try:
+    from recipe.randopt.randopt_ray_trainer import RandOptRayTrainer
+    from recipe.randopt.task_utils import create_prompt_processor, create_reward_fn, create_vote_fns, load_data
+except ModuleNotFoundError:
+    from randopt.randopt_ray_trainer import RandOptRayTrainer
+    from randopt.task_utils import create_prompt_processor, create_reward_fn, create_vote_fns, load_data
+
+
+@hydra.main(config_path="config", config_name="randopt_trainer", version_base=None)
+def main(config):
+    auto_set_device(config)
+    run_randopt(config)
+
+
+def run_randopt(config) -> None:
+    print(f"RandOpt hostname: {socket.gethostname()}, PID: {os.getpid()}")
+    pprint(OmegaConf.to_container(config, resolve=True))
+    OmegaConf.resolve(config)
+
+    if not ray.is_initialized():
+        ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
+        if not ray_init_kwargs:
+            ray_init_kwargs = {
+                "address": "local",
+                "include_dashboard": False,
+                "ignore_reinit_error": True,
+                "_temp_dir": tempfile.mkdtemp(prefix=f"ray_randopt_{int(time.time())}_"),
+            }
+        ray.init(**OmegaConf.to_container(ray_init_kwargs, resolve=True))
+
+    data_config = OmegaConf.to_container(config.data, resolve=True)
+    train_data = load_data(config.data.train_files)
+    eval_data = load_data(config.data.val_files) if config.data.get("val_files") else []
+    train_max_samples = int(config.data.get("train_max_samples", -1))
+    val_max_samples = int(config.data.get("val_max_samples", -1))
+    if train_max_samples > 0:
+        train_data = train_data[:train_max_samples]
+    if val_max_samples > 0:
+        eval_data = eval_data[:val_max_samples]
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        config.model.path,
+        trust_remote_code=config.model.get("trust_remote_code", False),
+    )
+    prompt_processor = create_prompt_processor(data_config)
+    reward_fn = create_reward_fn(data_config)
+    vote_answer_fn, vote_correct_fn = create_vote_fns(data_config)
+
+    trainer = RandOptRayTrainer(
+        config=config,
+        tokenizer=tokenizer,
+        reward_fn=reward_fn,
+        train_data=train_data,
+        eval_data=eval_data,
+        prompt_processor=prompt_processor,
+        vote_answer_fn=vote_answer_fn,
+        vote_correct_fn=vote_correct_fn,
+    )
+    trainer.init_workers(config.model.path)
+    trainer.fit()
+
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/randopt/randopt_ray_trainer.py
+++ b/randopt/randopt_ray_trainer.py
@@ -1,0 +1,489 @@
+"""Ray/vLLM trainer for the RandOpt recipe."""
+
+import gc
+import json
+import os
+import time
+from collections import Counter
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+import ray
+import torch
+from omegaconf import DictConfig, OmegaConf
+from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from tqdm import tqdm
+from vllm import LLM, SamplingParams
+from vllm.utils import get_ip, get_open_port
+
+from verl.utils.tracking import Tracking
+
+
+class RandOptLLM(LLM):
+    """vLLM wrapper that keeps CUDA visibility under Ray control."""
+
+    def __init__(self, *args, **kwargs):
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+        super().__init__(*args, **kwargs)
+
+
+class RandOptRayTrainer:
+    """Zeroth-order RandOpt trainer using parallel vLLM engines."""
+
+    def __init__(
+        self,
+        config: DictConfig,
+        tokenizer,
+        reward_fn,
+        train_data: list[dict[str, Any]],
+        eval_data: list[dict[str, Any]],
+        prompt_processor=None,
+        vote_answer_fn=None,
+        vote_correct_fn=None,
+    ):
+        self.config = config
+        self.randopt_config = config.randopt
+        self.tokenizer = tokenizer
+        self.reward_fn = reward_fn
+        self.train_data = train_data
+        self.eval_data = eval_data
+        self.prompt_processor = prompt_processor
+        self.vote_answer_fn = vote_answer_fn
+        self.vote_correct_fn = vote_correct_fn
+        self.engines = []
+        self.placement_groups = []
+        self._debug_samples_printed = 0
+
+        seed = self.randopt_config.get("global_seed")
+        if seed is not None:
+            self._set_global_seed(int(seed))
+
+    def _set_global_seed(self, seed: int) -> None:
+        import random
+
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        os.environ["PYTHONHASHSEED"] = str(seed)
+
+    def init_workers(self, model_path: str) -> None:
+        self._launch_engines(model_path)
+        self._init_inter_engine_group()
+
+    def _launch_engines(self, model_path: str) -> None:
+        num_engines = int(self.randopt_config.num_engines)
+        tensor_parallel_size = int(self.randopt_config.get("tensor_parallel_size", 1))
+        precision = self.randopt_config.get("precision", "bfloat16")
+        worker_extension_cls = self.randopt_config.get(
+            "worker_extension_cls", "recipe.randopt.worker_extension.WorkerExtension"
+        )
+
+        bundles = [{"GPU": 1, "CPU": 0} for _ in range(tensor_parallel_size)]
+        placement_groups = [placement_group(bundles, lifetime="detached") for _ in range(num_engines)]
+        ray.get([group.ready() for group in placement_groups])
+
+        strategies = [
+            PlacementGroupSchedulingStrategy(
+                placement_group=group,
+                placement_group_capture_child_tasks=True,
+                placement_group_bundle_index=0,
+            )
+            for group in placement_groups
+        ]
+
+        self.engines = [
+            ray.remote(num_cpus=0, num_gpus=0, scheduling_strategy=strategy)(RandOptLLM).remote(
+                model=model_path,
+                tensor_parallel_size=tensor_parallel_size,
+                distributed_executor_backend="ray",
+                worker_extension_cls=worker_extension_cls,
+                dtype=precision,
+                enable_prefix_caching=self.randopt_config.get("enable_prefix_caching", False),
+                enforce_eager=self.randopt_config.get("enforce_eager", True),
+                gpu_memory_utilization=self.randopt_config.get("gpu_memory_utilization", 0.85),
+                disable_log_stats=True,
+            )
+            for strategy in strategies
+        ]
+        self.placement_groups = placement_groups
+
+    def _init_inter_engine_group(self) -> None:
+        master_address = get_ip()
+        master_port = get_open_port()
+        ray.get(
+            [
+                engine.collective_rpc.remote(
+                    "init_inter_engine_group",
+                    args=(master_address, master_port, rank, len(self.engines)),
+                )
+                for rank, engine in enumerate(self.engines)
+            ]
+        )
+
+    def fit(self) -> None:
+        logging_dir = self._create_logging_dir()
+        logger = Tracking(
+            project_name=self.config.trainer.get("project_name", "randopt"),
+            experiment_name=self.config.trainer.get("experiment_name", "randopt-run"),
+            default_backend=self.config.trainer.get("logger", ["console"]),
+            config=OmegaConf.to_container(self.config, resolve=True),
+        )
+        self._save_config(logging_dir)
+
+        train_prompts = self._build_prompts(self.train_data)
+        sigma_values = self._get_sigma_values()
+        population_size = int(self.randopt_config.population_size)
+        global_seed = int(self.randopt_config.get("global_seed", 42))
+        top_k_values = self._get_top_k_values(population_size)
+
+        progress = tqdm(range(1), desc="RandOpt")
+        try:
+            for iteration in progress:
+                iteration_start = time.time()
+                rng = np.random.default_rng(seed=global_seed + iteration)
+                seeds = rng.choice(2**31, size=population_size, replace=False).tolist()
+                sigmas = rng.choice(sigma_values, size=population_size).tolist()
+                perturbations = [(int(seed), float(sigma)) for seed, sigma in zip(seeds, sigmas, strict=True)]
+                self._log_progress(
+                    f"iteration {iteration + 1}: evaluating {population_size} perturbations "
+                    f"across {len(self.engines)} engines"
+                )
+                perturbation_metrics = self._evaluate_population(perturbations, train_prompts, iteration)
+                metrics = self._summarize_train_metrics(perturbation_metrics, iteration, time.time() - iteration_start)
+                logger.log(data=metrics, step=iteration)
+                progress.set_postfix({"reward": f"{metrics['train/reward_mean']:.4f}"}, refresh=False)
+                self._log_progress(
+                    f"iteration {iteration + 1}: train reward mean={metrics['train/reward_mean']:.4f}, "
+                    f"max={metrics['train/reward_max']:.4f}, elapsed={metrics['train/iteration_time']:.1f}s"
+                )
+
+                top_perturbations = self._select_top_perturbations(perturbation_metrics, top_k_values)
+                if self.eval_data:
+                    self._log_progress(f"iteration {iteration + 1}: evaluating base model")
+                    logger.log(data=self._evaluate_model(iteration), step=iteration)
+                    self._log_progress(f"iteration {iteration + 1}: evaluating ensembles")
+                    ensemble_metrics = self._evaluate_ensemble(top_perturbations, top_k_values, iteration)
+                    logger.log(data=ensemble_metrics, step=iteration)
+
+                perturbation_metrics.clear()
+                gc.collect()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+        finally:
+            progress.close()
+            if hasattr(logger, "finish"):
+                logger.finish()
+            self._cleanup()
+
+    def _evaluate_population(
+        self,
+        perturbations: list[tuple[int, float]],
+        train_prompts,
+        iteration: int,
+    ) -> dict[tuple[int, float], dict]:
+        perturbation_metrics = {}
+        num_engines = len(self.engines)
+        total_batches = (len(perturbations) + num_engines - 1) // num_engines
+        for start in range(0, len(perturbations), num_engines):
+            batch_perturbations = perturbations[start : start + num_engines]
+            batch_idx = start // num_engines + 1
+            processed = min(start + len(batch_perturbations), len(perturbations))
+            self._log_progress(
+                f"iteration {iteration + 1}: population batch {batch_idx}/{total_batches} "
+                f"({processed}/{len(perturbations)} perturbations) perturbing weights"
+            )
+            ray.get(
+                [
+                    self.engines[index].collective_rpc.remote(
+                        "perturb_self_weights", args=(int(seed), float(sigma), False)
+                    )
+                    for index, (seed, sigma) in enumerate(batch_perturbations)
+                ]
+            )
+            sampling_params = SamplingParams(
+                temperature=self.randopt_config.get("temperature", 0.0),
+                seed=int(self.randopt_config.get("global_seed", 42)) + iteration,
+                max_tokens=int(self.randopt_config.get("max_tokens", 1024)),
+            )
+            self._log_progress(
+                f"iteration {iteration + 1}: population batch {batch_idx}/{total_batches} generating "
+                f"{len(train_prompts)} prompts on {len(batch_perturbations)} engines"
+            )
+            outputs_per_engine = ray.get(
+                [
+                    self.engines[index].generate.remote(train_prompts, sampling_params, use_tqdm=False)
+                    for index, _ in enumerate(batch_perturbations)
+                ]
+            )
+            self._log_progress(
+                f"iteration {iteration + 1}: population batch {batch_idx}/{total_batches} restoring weights"
+            )
+            ray.get(
+                [
+                    self.engines[index].collective_rpc.remote(
+                        "restore_self_weights", args=(int(seed), float(sigma), False)
+                    )
+                    for index, (seed, sigma) in enumerate(batch_perturbations)
+                ]
+            )
+            self._log_progress(
+                f"iteration {iteration + 1}: population batch {batch_idx}/{total_batches} scoring outputs"
+            )
+            for index, perturbation in enumerate(batch_perturbations):
+                perturbation_metrics[perturbation] = self._compute_metrics(outputs_per_engine[index], self.train_data)
+            del outputs_per_engine
+        return perturbation_metrics
+
+    def _get_sigma_values(self) -> list[float]:
+        sigma_list = self.randopt_config.get("sigma_list", None)
+        if sigma_list is None:
+            return [float(self.randopt_config.sigma)]
+        if isinstance(sigma_list, str):
+            return [float(value.strip()) for value in sigma_list.split(",")]
+        return [float(value) for value in sigma_list]
+
+    def _get_top_k_values(self, population_size: int) -> list[int]:
+        top_k_values = self.randopt_config.get("top_k_values", None)
+        if top_k_values is not None and len(top_k_values) > 0:
+            values = [int(value) for value in top_k_values]
+        else:
+            ratios = self.randopt_config.get("top_k_ratios", [0.02, 0.1])
+            if isinstance(ratios, str):
+                ratios = [float(value.strip()) for value in ratios.split(",")]
+            values = [max(1, int(float(ratio) * population_size)) for ratio in ratios]
+        return sorted({min(population_size, value) for value in values})
+
+    def _select_top_perturbations(
+        self,
+        perturbation_metrics: dict[tuple[int, float], dict],
+        top_k_values: list[int],
+    ) -> list[tuple[int, float]]:
+        max_k = max(top_k_values)
+        ranked = sorted(perturbation_metrics.items(), key=lambda item: item[1]["avg_reward"], reverse=True)
+        print("\n[RandOpt] Top perturbations by train reward:")
+        for rank, ((seed, sigma), metrics) in enumerate(ranked[: min(max_k, 10)], start=1):
+            print(f"  {rank}. seed={seed}, sigma={sigma}, reward={metrics['avg_reward']:.4f}")
+        return [(int(seed), float(sigma)) for (seed, sigma), _ in ranked[:max_k]]
+
+    def _evaluate_ensemble(
+        self,
+        top_perturbations: list[tuple[int, float]],
+        top_k_values: list[int],
+        step: int,
+    ) -> dict[str, float]:
+        if self.vote_answer_fn is None or self.vote_correct_fn is None:
+            return {"ensemble/skipped": 1.0, "training/global_step": step}
+
+        eval_prompts = self._build_prompts(self.eval_data)
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            seed=int(self.randopt_config.get("global_seed", 42)),
+            max_tokens=int(self.randopt_config.get("max_tokens", 1024)),
+        )
+
+        max_k = min(max(top_k_values), len(top_perturbations))
+        all_answers: list[list[str] | None] = [None] * max_k
+        num_engines = len(self.engines)
+        total_batches = (max_k + num_engines - 1) // num_engines
+
+        for start in range(0, max_k, num_engines):
+            batch_perturbations = top_perturbations[start : start + num_engines]
+            batch_idx = start // num_engines + 1
+            self._log_progress(
+                f"ensemble batch {batch_idx}/{total_batches}: perturbing top perturbations "
+                f"({start + len(batch_perturbations)}/{max_k})"
+            )
+            ray.get(
+                [
+                    self.engines[index].collective_rpc.remote(
+                        "perturb_self_weights", args=(int(seed), float(sigma), False)
+                    )
+                    for index, (seed, sigma) in enumerate(batch_perturbations)
+                ]
+            )
+            self._log_progress(
+                f"ensemble batch {batch_idx}/{total_batches}: generating {len(eval_prompts)} eval prompts"
+            )
+            batch_outputs = ray.get(
+                [
+                    self.engines[index].generate.remote(eval_prompts, sampling_params, use_tqdm=False)
+                    for index, _ in enumerate(batch_perturbations)
+                ]
+            )
+            self._log_progress(f"ensemble batch {batch_idx}/{total_batches}: restoring weights")
+            ray.get(
+                [
+                    self.engines[index].collective_rpc.remote(
+                        "restore_self_weights", args=(int(seed), float(sigma), False)
+                    )
+                    for index, (seed, sigma) in enumerate(batch_perturbations)
+                ]
+            )
+
+            for local_idx, global_idx in enumerate(range(start, start + len(batch_perturbations))):
+                answers_for_model = []
+                for output, task_data in zip(batch_outputs[local_idx], self.eval_data, strict=False):
+                    answer, is_valid, _ = self.vote_answer_fn(output.outputs[0].text, task_data)
+                    answers_for_model.append(answer if is_valid else "")
+                all_answers[global_idx] = answers_for_model
+            del batch_outputs
+
+        metrics = {"training/global_step": step}
+        previous_k = None
+        previous_final_answers = None
+        previous_correct_flags = None
+        for k_value in top_k_values:
+            if k_value > max_k:
+                continue
+            correct = 0
+            final_answers = []
+            correct_flags = []
+            valid_vote_counts = []
+            for sample_idx, task_data in enumerate(self.eval_data):
+                answers = [
+                    model_answers[sample_idx]
+                    for model_answers in all_answers[:k_value]
+                    if model_answers is not None and model_answers[sample_idx]
+                ]
+                valid_vote_counts.append(len(answers))
+                final_answer = ""
+                if answers:
+                    final_answer = Counter(answers).most_common(1)[0][0]
+                    is_correct = self.vote_correct_fn(final_answer, task_data)
+                    if is_correct:
+                        correct += 1
+                else:
+                    is_correct = False
+                final_answers.append(final_answer)
+                correct_flags.append(is_correct)
+            accuracy = correct / len(self.eval_data) * 100 if self.eval_data else 0.0
+            metrics[f"ensemble/top_{k_value}_accuracy"] = accuracy
+            metrics[f"ensemble/top_{k_value}_correct"] = float(correct)
+            metrics[f"ensemble/top_{k_value}_valid_vote_mean"] = float(np.mean(valid_vote_counts))
+            metrics[f"ensemble/top_{k_value}_valid_vote_min"] = float(np.min(valid_vote_counts))
+            metrics[f"ensemble/top_{k_value}_coverage"] = float(
+                np.mean([count > 0 for count in valid_vote_counts]) * 100.0
+            )
+            if previous_final_answers is not None and previous_correct_flags is not None:
+                changed = sum(
+                    before != after for before, after in zip(previous_final_answers, final_answers, strict=True)
+                )
+                correctness_changed = sum(
+                    before != after for before, after in zip(previous_correct_flags, correct_flags, strict=True)
+                )
+                metrics[f"ensemble/top_{previous_k}_to_top_{k_value}_prediction_changed"] = float(changed)
+                metrics[f"ensemble/top_{previous_k}_to_top_{k_value}_correctness_changed"] = float(correctness_changed)
+                print(
+                    f"[RandOpt] ensemble top-{previous_k}->top-{k_value}: "
+                    f"prediction changed on {changed}/{len(self.eval_data)}, "
+                    f"correctness changed on {correctness_changed}/{len(self.eval_data)}"
+                )
+            print(f"[RandOpt] ensemble top-{k_value}: {accuracy:.2f}% ({correct}/{len(self.eval_data)})")
+            previous_k = k_value
+            previous_final_answers = final_answers
+            previous_correct_flags = correct_flags
+        return metrics
+
+    def _log_progress(self, message: str) -> None:
+        print(f"[RandOpt progress] {message}", flush=True)
+
+    def _compute_metrics(
+        self,
+        outputs,
+        task_datas: list[dict[str, Any]],
+        debug_prefix: str | None = None,
+    ) -> dict[str, Any]:
+        rewards = []
+        format_rewards = []
+        answer_rewards = []
+        for sample_idx, (output, task_data) in enumerate(zip(outputs, task_datas, strict=False)):
+            response = output.outputs[0].text
+            result = self.reward_fn(response, task_data)
+            if isinstance(result, dict):
+                rewards.append(float(result.get("reward", 0.0)))
+                reward_info = result.get("reward_info", {})
+                format_rewards.append(float(reward_info.get("format_reward", 0.0)))
+                answer_rewards.append(float(reward_info.get("answer_reward", 0.0)))
+            else:
+                rewards.append(float(result))
+            debug_max_samples = int(self.randopt_config.get("debug_max_samples", 4))
+            if debug_prefix and self._debug_samples_printed < debug_max_samples:
+                print(f"\n[RandOpt debug] {debug_prefix} sample")
+                print(f"sample_idx={sample_idx}")
+                print(f"task_data={task_data}")
+                print(f"response={response[:1000]}")
+                print(f"reward={result}\n")
+                self._debug_samples_printed += 1
+        return {
+            "avg_reward": float(np.mean(rewards)) if rewards else 0.0,
+            "avg_format": float(np.mean(format_rewards)) if format_rewards else 0.0,
+            "avg_answer": float(np.mean(answer_rewards)) if answer_rewards else 0.0,
+            "accuracy": float(np.mean([reward > 0 for reward in answer_rewards]) * 100.0) if answer_rewards else 0.0,
+        }
+
+    def _evaluate_model(self, step: int) -> dict[str, float]:
+        if not self.eval_data:
+            return {}
+        eval_prompts = self._build_prompts(self.eval_data)
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            seed=int(self.randopt_config.get("global_seed", 42)),
+            max_tokens=int(self.randopt_config.get("max_tokens", 1024)),
+        )
+        outputs = ray.get(self.engines[0].generate.remote(eval_prompts, sampling_params, use_tqdm=False))
+        metrics = self._compute_metrics(
+            outputs,
+            self.eval_data,
+            debug_prefix=f"eval step {step}" if self.randopt_config.get("debug_print_samples", False) else None,
+        )
+        return {
+            "eval/avg_reward": metrics["avg_reward"],
+            "eval/format_reward": metrics["avg_format"],
+            "eval/answer_reward": metrics["avg_answer"],
+            "eval/accuracy": metrics["accuracy"],
+            "training/global_step": step,
+        }
+
+    def _build_prompts(self, data: list[dict[str, Any]]):
+        if self.prompt_processor:
+            return [self.prompt_processor(row, self.tokenizer) for row in data]
+        return [row.get("prompt", row.get("context")) for row in data]
+
+    def _summarize_train_metrics(
+        self, perturbation_metrics: dict[tuple[int, float], dict], iteration: int, elapsed: float
+    ) -> dict[str, float]:
+        rewards = [metrics["avg_reward"] for metrics in perturbation_metrics.values()]
+        return {
+            "train/reward_mean": float(np.mean(rewards)) if rewards else 0.0,
+            "train/reward_std": float(np.std(rewards)) if rewards else 0.0,
+            "train/reward_min": float(np.min(rewards)) if rewards else 0.0,
+            "train/reward_max": float(np.max(rewards)) if rewards else 0.0,
+            "train/iteration_time": elapsed,
+            "training/global_step": iteration,
+        }
+
+    def _create_logging_dir(self) -> str:
+        base_dir = self.config.trainer.get("default_local_dir", "/tmp/verl/randopt_checkpoints")
+        logging_dir = os.path.join(base_dir, f"randopt_{datetime.now().strftime('%Y%m%d_%H%M%S')}")
+        os.makedirs(logging_dir, exist_ok=True)
+        return logging_dir
+
+    def _save_config(self, logging_dir: str) -> None:
+        with open(os.path.join(logging_dir, "config.json"), "w") as f:
+            json.dump(OmegaConf.to_container(self.config, resolve=True), f, indent=2)
+
+    def _cleanup(self) -> None:
+        for engine in self.engines:
+            try:
+                ray.kill(engine)
+            except Exception:
+                pass
+        for group in self.placement_groups:
+            try:
+                remove_placement_group(group)
+            except Exception:
+                pass

--- a/randopt/run_countdown_example.py
+++ b/randopt/run_countdown_example.py
@@ -1,0 +1,144 @@
+"""Run a RandOpt Countdown example."""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _set_default_env() -> None:
+    cuda_home = os.environ.get("CUDA_HOME", "/usr/local/cuda")
+    if Path(cuda_home).is_dir():
+        os.environ["CUDA_HOME"] = cuda_home
+        os.environ["PATH"] = f"{cuda_home}/bin:{os.environ.get('PATH', '')}"
+        _prepend_env_path("CPATH", f"{cuda_home}/include")
+        _prepend_env_path("CPLUS_INCLUDE_PATH", f"{cuda_home}/include")
+        _prepend_env_path("LIBRARY_PATH", f"{cuda_home}/lib64")
+        _prepend_env_path("LD_LIBRARY_PATH", f"{cuda_home}/lib64")
+
+    defaults = {
+        "VLLM_USE_FLASHINFER_SAMPLER": "0",
+        "VLLM_DISABLE_FLASHINFER_PREFILL": "1",
+        "VLLM_ATTENTION_BACKEND": "TORCH_SDPA",
+        "TRANSFORMERS_ATTN_IMPLEMENTATION": "sdpa",
+        "VLLM_NO_USAGE_STATS": "1",
+    }
+    for key, value in defaults.items():
+        os.environ.setdefault(key, value)
+
+    cuda_devices = os.environ.get("CUDA_DEVICES")
+    if cuda_devices:
+        os.environ["CUDA_VISIBLE_DEVICES"] = cuda_devices
+
+
+def _prepend_env_path(name: str, value: str) -> None:
+    current = os.environ.get(name)
+    os.environ[name] = f"{value}:{current}" if current else value
+
+
+def _check_dependencies() -> None:
+    missing = [name for name in ("verl", "ray", "vllm", "transformers") if importlib.util.find_spec(name) is None]
+    if missing:
+        raise RuntimeError(
+            f"Missing Python dependencies: {', '.join(missing)}. "
+            "Install them with: pip install verl==0.7.1 vllm ray pandas pyarrow tqdm"
+        )
+
+
+def _repeat_records(records: list[dict], count: int) -> list[dict]:
+    if count <= 0:
+        return records
+    return [dict(records[index % len(records)]) for index in range(count)]
+
+
+def _write_countdown_data(smoke_dir: Path, train_count: int, val_count: int) -> tuple[Path, Path]:
+    records = [
+        {"numbers": [1, 2, 3, 4], "target": 10},
+        {"numbers": [1, 1, 1, 1], "target": 4},
+        {"numbers": [2, 2, 2, 2], "target": 8},
+        {"numbers": [3, 3, 3, 3], "target": 12},
+        {"numbers": [2, 3, 5, 7], "target": 17},
+        {"numbers": [1, 4, 6, 8], "target": 19},
+        {"numbers": [2, 4, 6, 8], "target": 20},
+        {"numbers": [3, 3, 6, 9], "target": 21},
+        {"numbers": [1, 5, 5, 10], "target": 20},
+        {"numbers": [2, 2, 7, 9], "target": 20},
+        {"numbers": [4, 4, 5, 6], "target": 19},
+    ]
+    smoke_dir.mkdir(parents=True, exist_ok=True)
+    train_file = smoke_dir / "countdown_train.json"
+    val_file = smoke_dir / "countdown_val.json"
+    train_file.write_text(json.dumps(_repeat_records(records, train_count)))
+    val_file.write_text(json.dumps(_repeat_records(records, val_count)))
+    return train_file, val_file
+
+
+def main() -> None:
+    _set_default_env()
+    _check_dependencies()
+
+    package = __package__ or "randopt"
+    main_module = f"{package}.main_randopt"
+    worker_extension_cls = f"{package}.worker_extension.WorkerExtension"
+
+    smoke_dir = Path(os.environ.get("SMOKE_DIR", "outputs/randopt_smoke"))
+    train_max_samples = os.environ.get("TRAIN_MAX_SAMPLES", "20")
+    val_max_samples = os.environ.get("VAL_MAX_SAMPLES", "200")
+    train_file = Path(os.environ["TRAIN_FILE"]) if os.environ.get("TRAIN_FILE") else None
+    val_file = Path(os.environ["VAL_FILE"]) if os.environ.get("VAL_FILE") else None
+    if train_file is None or val_file is None:
+        train_file, val_file = _write_countdown_data(smoke_dir, int(train_max_samples), int(val_max_samples))
+        print(f"Wrote {train_file} ({train_max_samples} train) and {val_file} ({val_max_samples} val)")
+
+    log_file = Path(os.environ.get("LOG_FILE", smoke_dir / "randopt_smoke.log"))
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    command = [
+        sys.executable,
+        "-m",
+        main_module,
+        f"model.path={os.environ.get('MODEL_PATH', 'Qwen/Qwen2.5-1.5B-Instruct')}",
+        "data.task_type=countdown",
+        f"data.train_files={train_file}",
+        f"data.val_files={val_file}",
+        f"data.train_max_samples={train_max_samples}",
+        f"data.val_max_samples={val_max_samples}",
+        "randopt.sigma=0.001",
+        f"randopt.sigma_list={os.environ.get('SIGMA_LIST', 'null')}",
+        f"randopt.population_size={os.environ.get('POPULATION_SIZE', '500')}",
+        f"randopt.top_k_ratios={os.environ.get('TOP_K_RATIOS', '[0.02,0.1]')}",
+        f"randopt.num_engines={os.environ.get('NUM_ENGINES', os.environ.get('N_GPUS', '6'))}",
+        f"randopt.tensor_parallel_size={os.environ.get('TP', '1')}",
+        "randopt.precision=bfloat16",
+        f"randopt.max_tokens={os.environ.get('MAX_TOKENS', '512')}",
+        "randopt.temperature=0.0",
+        f"randopt.gpu_memory_utilization={os.environ.get('GPU_MEMORY_UTILIZATION', '0.6')}",
+        f"randopt.worker_extension_cls={worker_extension_cls}",
+        f"randopt.debug_print_samples={os.environ.get('DEBUG_PRINT_SAMPLES', '1')}",
+        f"randopt.debug_max_samples={os.environ.get('DEBUG_MAX_SAMPLES', '4')}",
+        'trainer.logger=["console"]',
+        f"trainer.project_name={os.environ.get('PROJECT_NAME', 'randopt-smoke')}",
+        f"trainer.experiment_name={os.environ.get('EXP_NAME', 'countdown-smoke')}",
+        f"trainer.n_gpus_per_node={os.environ.get('N_GPUS', '1')}",
+        "trainer.nnodes=1",
+        f"trainer.default_local_dir={os.environ.get('CKPTS_DIR', str(smoke_dir / 'ckpts'))}",
+        f"trainer.total_epochs={os.environ.get('TOTAL_EPOCHS', '1')}",
+        "trainer.test_freq=1",
+    ]
+
+    with log_file.open("w") as log:
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        assert process.stdout is not None
+        for line in process.stdout:
+            print(line, end="")
+            log.write(line)
+        return_code = process.wait()
+    if return_code != 0:
+        raise SystemExit(return_code)
+    print(f"Smoke test log: {log_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/randopt/task_utils.py
+++ b/randopt/task_utils.py
@@ -1,0 +1,231 @@
+"""Task helpers for the RandOpt recipe."""
+
+import json
+import re
+from typing import Any
+
+DEFAULT_SYSTEM_MESSAGE = (
+    "You are a helpful assistant. You first think about the reasoning process "
+    "in your mind and then provide the user with the answer."
+)
+COUNTDOWN_USER_TEMPLATE = (
+    "Using the numbers {numbers}, create an equation that equals {target}. "
+    "You can use basic arithmetic operations (+, -, *, /) and each number can only be used once. "
+    "Show your work in <think> </think> tags. "
+    "Return the final answer in <answer> </answer> tags, for example "
+    "<answer> (1 + 2) / 3 </answer>."
+)
+COUNTDOWN_RESPONSE_PROMPT = "Let me solve this step by step.\n<think>"
+
+
+def load_data(file_path: str | list[str]) -> list[dict[str, Any]]:
+    """Load JSON or parquet records."""
+    if isinstance(file_path, list):
+        file_path = file_path[0]
+    if file_path.endswith(".parquet"):
+        import pandas as pd
+
+        return pd.read_parquet(file_path).to_dict("records")
+    with open(file_path) as f:
+        return json.load(f)
+
+
+def _apply_chat_template(messages: list[dict[str, str]], tokenizer) -> str:
+    if getattr(tokenizer, "chat_template", None):
+        return tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+
+    rendered = []
+    for message in messages:
+        role = message.get("role", "")
+        content = message.get("content", "")
+        if role == "system":
+            rendered.append(f"{content}\n\n")
+        elif role == "user":
+            rendered.append(f"### Input:\n{content}\n\n### Output:\n")
+        else:
+            rendered.append(content)
+    return "".join(rendered)
+
+
+def _to_tokens_prompt(text: str, tokenizer):
+    from vllm import TokensPrompt
+
+    tokenized = tokenizer(text)
+    return TokensPrompt(prompt_token_ids=tokenized["input_ids"])
+
+
+def create_prompt_processor(config: dict[str, Any]):
+    """Create a prompt processor for countdown, verl parquet, or custom data."""
+    task_type = config.get("task_type", "countdown")
+    if task_type == "custom":
+        prompt_processor_path = config.get("prompt_processor_path")
+        prompt_processor_name = config.get("prompt_processor_name")
+        if not prompt_processor_path or not prompt_processor_name:
+            return None
+        from verl.utils.import_utils import load_extern_object
+
+        return load_extern_object(prompt_processor_path, prompt_processor_name)
+
+    if task_type == "parquet_prompt":
+
+        def process_parquet_prompt(task_data: dict[str, Any], tokenizer):
+            prompt = task_data.get("prompt", task_data.get("context"))
+            if isinstance(prompt, str):
+                return _to_tokens_prompt(prompt, tokenizer)
+            messages = [dict(message) for message in list(prompt)]
+            return _to_tokens_prompt(_apply_chat_template(messages, tokenizer), tokenizer)
+
+        return process_parquet_prompt
+
+    if task_type != "countdown":
+        raise ValueError("RandOpt recipe currently supports task_type=countdown, parquet_prompt, or custom.")
+
+    system_message = config.get("system_message") or DEFAULT_SYSTEM_MESSAGE
+    user_template = config.get("user_template") or COUNTDOWN_USER_TEMPLATE
+
+    def process_countdown(task_data: dict[str, Any], tokenizer):
+        numbers, target = get_countdown_ground_truth(task_data)
+        user_content = user_template.format(numbers=numbers, target=target)
+        messages = [{"role": "system", "content": system_message}, {"role": "user", "content": user_content}]
+        return _to_tokens_prompt(_apply_chat_template(messages, tokenizer), tokenizer)
+
+    return process_countdown
+
+
+def create_reward_fn(config: dict[str, Any]):
+    """Create a reward function for countdown or a user-provided custom task."""
+    task_type = config.get("task_type", "countdown")
+    if task_type == "custom":
+        reward_fn_path = config.get("reward_fn_path")
+        reward_fn_name = config.get("reward_fn_name")
+        if not reward_fn_path or not reward_fn_name:
+            raise ValueError("custom task_type requires reward_fn_path and reward_fn_name.")
+        from verl.utils.import_utils import load_extern_object
+
+        return load_extern_object(reward_fn_path, reward_fn_name)
+    if task_type == "parquet_prompt":
+        raise ValueError("parquet_prompt requires a custom reward_fn_path/reward_fn_name.")
+    if task_type != "countdown":
+        raise ValueError("RandOpt recipe currently supports task_type=countdown or custom.")
+    return countdown_reward
+
+
+def create_vote_fns(config: dict[str, Any]):
+    """Create answer extraction and correctness functions for ensemble voting."""
+    task_type = config.get("task_type", "countdown")
+    if task_type == "countdown":
+        return countdown_vote_answer, countdown_is_voted_answer_correct
+    return None, None
+
+
+def get_countdown_ground_truth(task_data: dict[str, Any]) -> tuple[list[int], int]:
+    if "reward_model" in task_data and "ground_truth" in task_data["reward_model"]:
+        ground_truth = task_data["reward_model"]["ground_truth"]
+        if isinstance(ground_truth, str):
+            ground_truth = json.loads(ground_truth)
+        return list(ground_truth["numbers"]), int(ground_truth["target"])
+    return list(task_data["numbers"]), int(task_data["target"])
+
+
+def countdown_reward(
+    response: str,
+    task_data: dict[str, Any],
+) -> dict[str, Any]:
+    numbers, target = get_countdown_ground_truth(task_data)
+    full_response = f"<think>{response}"
+    format_reward = _countdown_format_reward(full_response)
+    answer_reward, answer_info = _countdown_answer_reward(full_response, numbers, target)
+    return {
+        "reward": 0.1 * format_reward + answer_reward,
+        "reward_info": {
+            "format_reward": format_reward,
+            "answer_reward": answer_reward,
+            **answer_info,
+        },
+    }
+
+
+def _countdown_format_reward(response: str) -> float:
+    think_match = re.search(r"<think>.*?</think>", response, re.DOTALL)
+    answer_match = re.search(r"<answer>.*?</answer>", response, re.DOTALL)
+    full_match = re.match(r"^<think>.*?</think>\n<answer>.*?</answer>$", response, re.DOTALL)
+    if full_match:
+        return 1.0
+    return (0.1 if think_match else 0.0) + (0.5 if answer_match else 0.0)
+
+
+def _countdown_answer_reward(response: str, numbers: list[int], target: int) -> tuple[float, dict[str, Any]]:
+    matches = re.findall(r"<answer>(.*?)</answer>", response, re.DOTALL)
+    if not matches:
+        return 0.0, {"reject_reason": "no_answer", "pred_answer": ""}
+    expression = matches[-1].strip()
+    if not re.match(r"^[0-9+\-*/() ]+$", expression):
+        return 0.0, {"reject_reason": "invalid_chars", "pred_answer": expression}
+    used_numbers = [int(number) for number in re.findall(r"\d+", expression)]
+    if sorted(used_numbers) != sorted(numbers):
+        return 0.0, {
+            "reject_reason": "wrong_numbers",
+            "pred_answer": expression,
+            "used_numbers": used_numbers,
+            "expected_numbers": numbers,
+        }
+    try:
+        result = eval(expression, {"__builtins__": None}, {})
+    except Exception:
+        return 0.0, {"reject_reason": "eval_error", "pred_answer": expression}
+    if abs(float(result) - float(target)) < 1e-5:
+        return 1.0, {"reject_reason": None, "pred_answer": expression, "result": float(result)}
+    return 0.0, {
+        "reject_reason": "wrong_result",
+        "pred_answer": expression,
+        "result": float(result),
+        "target": target,
+    }
+
+
+def countdown_vote_answer(response: str, task_data: dict[str, Any]) -> tuple[str, bool, dict[str, Any] | None]:
+    """Extract a numeric answer for majority voting.
+
+    Countdown votes on the evaluated numeric result of valid formulas, matching
+    the original RandOpt implementation.
+    """
+    numbers, _ = get_countdown_ground_truth(task_data)
+    matches = re.findall(r"<answer>(.*?)</answer>", response, re.DOTALL)
+    if not matches:
+        return "", False, {"reject_reason": "no_answer", "pred_answer": ""}
+
+    expression = matches[-1].strip()
+    if not re.match(r"^[0-9+\-*/() ]+$", expression):
+        return "", False, {"reject_reason": "invalid_chars", "pred_answer": expression}
+
+    used_numbers = [int(number) for number in re.findall(r"\d+", expression)]
+    if sorted(used_numbers) != sorted(numbers):
+        return (
+            "",
+            False,
+            {
+                "reject_reason": "wrong_numbers",
+                "pred_answer": expression,
+                "used_numbers": used_numbers,
+                "expected_numbers": numbers,
+            },
+        )
+
+    try:
+        result = eval(expression, {"__builtins__": None}, {})
+    except (SyntaxError, ZeroDivisionError, TypeError, ValueError, OverflowError) as exc:
+        return "", False, {"reject_reason": "eval_error", "pred_answer": expression, "error": str(exc)}
+
+    if abs(float(result) - round(float(result))) < 1e-9:
+        return str(int(round(float(result)))), True, None
+    return str(float(result)), True, None
+
+
+def countdown_is_voted_answer_correct(voted_answer: str, task_data: dict[str, Any]) -> bool:
+    if not voted_answer:
+        return False
+    _, target = get_countdown_ground_truth(task_data)
+    try:
+        return abs(float(voted_answer) - float(target)) < 1e-5
+    except ValueError:
+        return False

--- a/randopt/worker_extension.py
+++ b/randopt/worker_extension.py
@@ -1,0 +1,125 @@
+"""vLLM worker extension used by the RandOpt recipe.
+
+The extension runs inside each vLLM worker process. It exposes small RPC
+methods for applying deterministic Gaussian perturbations, updating one worker
+from a list of seeds, and synchronizing updated weights across engines.
+"""
+
+import gc
+import os
+import random
+import time
+
+import numpy as np
+import torch
+
+
+def _stateless_init_process_group(master_address, master_port, rank, world_size, device):
+    from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from vllm.distributed.utils import StatelessProcessGroup
+
+    process_group = StatelessProcessGroup.create(
+        host=master_address, port=master_port, rank=rank, world_size=world_size
+    )
+    return PyNcclCommunicator(process_group, device=device)
+
+
+class WorkerExtension:
+    """RPC surface for RandOpt perturbation and inter-engine synchronization."""
+
+    _VISUAL_PREFIXES = ("visual.", "model.visual.")
+
+    def _set_seed(self, seed: int) -> None:
+        seed = int(seed)
+        self.local_seed = seed
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+    def _should_perturb(self, name: str) -> bool:
+        if os.environ.get("RANDOPT_PERTURB_VISUAL", "0") == "1":
+            return True
+        return not name.startswith(self._VISUAL_PREFIXES)
+
+    def perturb_self_weights(self, seed, noise_scale, negate=False):
+        self._set_seed(seed)
+        sign = -1.0 if negate else 1.0
+        scale = float(noise_scale)
+
+        for name, param in self.model_runner.model.named_parameters():
+            if not self._should_perturb(name):
+                continue
+            generator = torch.Generator(device=param.device)
+            generator.manual_seed(int(seed))
+            noise = torch.randn(param.shape, dtype=param.dtype, device=param.device, generator=generator)
+            param.data.add_(sign * scale * noise)
+            del noise
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        return True
+
+    def restore_self_weights(self, seed, noise_scale, negate=False):
+        self._set_seed(seed)
+        sign = -1.0 if negate else 1.0
+        scale = float(noise_scale)
+
+        for name, param in self.model_runner.model.named_parameters():
+            if not self._should_perturb(name):
+                continue
+            generator = torch.Generator(device=param.device)
+            generator.manual_seed(int(seed))
+            noise = torch.randn(param.shape, dtype=param.dtype, device=param.device, generator=generator)
+            param.data.add_(-sign * scale * noise)
+            del noise
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        return True
+
+    def update_weights_from_seeds(self, seeds, coeffs, alpha, population_size):
+        """Apply a normalized ES update on the current worker."""
+        for name, param in self.model_runner.model.named_parameters():
+            if not self._should_perturb(name):
+                continue
+
+            update_accumulator = torch.zeros_like(param.data, dtype=torch.float32)
+            for seed, coeff in zip(seeds, coeffs, strict=False):
+                generator = torch.Generator(device=param.device)
+                generator.manual_seed(int(seed))
+                noise = torch.randn(param.shape, dtype=param.dtype, device=param.device, generator=generator)
+                update_accumulator.add_(noise.to(torch.float32), alpha=float(coeff))
+                del noise
+
+            update_accumulator.mul_(float(alpha) / int(population_size))
+            param.data.add_(update_accumulator.to(param.dtype))
+            del update_accumulator
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        gc.collect()
+        return True
+
+    def init_inter_engine_group(self, master_address: str, master_port: int, rank: int, world_size: int):
+        self.inter_pg = _stateless_init_process_group(master_address, master_port, rank, world_size, self.device)
+        return True
+
+    def broadcast_all_weights(self, src_rank: int):
+        for _, param in self.model_runner.model.named_parameters():
+            self.inter_pg.broadcast(param, src=int(src_rank), stream=torch.cuda.current_stream())
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        return True
+
+    def save_self_weights_to_disk(self, filepath: str):
+        state_dict = {name: param.detach().cpu() for name, param in self.model_runner.model.named_parameters()}
+        torch.save(state_dict, filepath)
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        time.sleep(0.1)
+        return True


### PR DESCRIPTION
## What does this PR do?

This PR adds the implementation of the paper **"Neural Thickets: Diverse Task Experts Are Dense Around Pretrained Weights"** (ICML 2026 Spotlight, [arXiv:2603.12228](https://arxiv.org/abs/2603.12228)).

RandOpt in this implementation:
1. Samples Gaussian perturbations around a pretrained model.
2. Evaluates perturbed models in parallel with vLLM.
3. Selects top-performing perturbations by reward.
4. Reports majority-vote ensemble accuracy for selected top-k sets.

---

## Test

```bash
python3 -m randopt.run_countdown_example
```

---

## Test  result

```bash
train/reward_mean: 0.1045
train/reward_std: 0.0664
train/reward_min: 0.0130
train/reward_max: 0.3820
ensemble/top_10_accuracy: 42.0%
ensemble/top_50_accuracy: 64.0%
```


## Usage from verl repo root

```bash
python3 -m recipe.randopt.main_randopt \
  model.path=Qwen/Qwen2.5-3B-Instruct \
  data.task_type=countdown \
  data.train_files=data/countdown/train.parquet \
  data.val_files=data/countdown/test.parquet \
  randopt.worker_extension_cls=recipe.randopt.worker_extension.WorkerExtension
```

## Quick local example

```bash
python3 -m recipe.randopt.run_countdown_example
Standalone verl-recipe repo usage
python3 -m randopt.run_countdown_example
python3 -m randopt.main_randopt ...
```

## Design & Code Changes

### High-level design

This PR adds a full RandOpt pipeline for perturbation-based policy optimization with parallel rollout/evaluation and top-k majority-vote ensemble reporting.

## Main Files and Responsibilities

### `randopt/randopt_ray_trainer.py`
- Core RandOpt training/evaluation loop.
- Parallel perturbation evaluation with multiple vLLM engines.
- Top-k selection and ensemble metric computation.

### `randopt/main_randopt.py`
- Main entrypoint for launching RandOpt training with config.

### `randopt/task_utils.py`
- Task-specific utilities (Countdown/parquet/custom prompt+reward plumbing).

### `randopt/worker_extension.py`
- Worker extension hooks used by the trainer/runtime.

### `randopt/config/randopt_trainer.yaml`
- Default RandOpt configuration and trainer/runtime knobs.

### `randopt/run_countdown_example.py`
- One-command toy data generation + smoke test path.

### `randopt/README.md`
- Setup, run instructions, common overrides, custom task usage, and citation.

### `randopt/REQUIRED_VERL.txt`
- Pinned tested `verl` version metadata.