### PR TITLE
[worker] feat: add diff of training/rollout probs

### DIFF
--- a/dapo/dapo_ray_trainer.py
+++ b/dapo/dapo_ray_trainer.py
@@ -329,6 +329,10 @@ class RayDAPOTrainer(RayPPOTrainer):
                         batch, is_metrics = compute_rollout_correction_and_add_to_batch(batch, rollout_corr_config)
                         # IS and off-policy metrics already have rollout_corr/ prefix
                         metrics.update(is_metrics)
+                        # add diff of probs too.
+                        from verl.utils.debug.metrics import calculate_debug_metrics
+
+                        metrics.update(calculate_debug_metrics(batch))
 
                     with marked_timer("adv", timing_raw, "brown"):
                         # compute advantages, executed on the driver process


### PR DESCRIPTION
add diff of training/rollout probs

            "training/rollout_probs_diff_valid": 1->input is valid, 0->input is invalid
            "training/rollout_probs_diff_max": max value of logprob diff of rollout vs. actor
            "training/rollout_probs_diff_mean": mean value of logprob diff of rollout vs. actor
            "training/rollout_probs_diff_std": std value of logprob diff of rollout vs. actor
            "training/rollout_actor_probs_pearson_corr": logprob's pearson corrcoef of rollout vs. actor
