### PR TITLE
feat: add gkd_ascend recipe with NPU support and FSDP backend

### DIFF
--- a/gkd_ascend/README.md
+++ b/gkd_ascend/README.md
@@ -1,0 +1,299 @@
+# Recipe: Async On-Policy Knowledge Distillation Trainer on Ascend NPU
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode (rolling `main`, pinned release tag, or pinned git commit), and copy-pastable `pip` / `git` instructions where they exist.
+
+This recipe extends the [GKD (On-Policy Knowledge Distillation)](../gkd/megatron/README.md) recipe with **Ascend NPU support** and **FSDP/FSDP2 backend support**, enabling knowledge distillation training on Huawei Ascend NPUs and providing an alternative to the Megatron-based training backend.
+
+## 1. Background
+
+On-policy knowledge distillation (KD) trains a student policy to imitate a stronger teacher using samples drawn from the student's current policy. For each on-policy rollout the teacher returns soft, top-k token distributions and the student is optimized with a token-wise sparse KL objective that focuses learning on the teacher's high-probability modes. Because training examples come from the student's own state distribution, KD reduces distributional mismatch relative to off-policy distillation or supervised fine-tuning (SFT), improving stability and sample efficiency. Compared with reinforcement learning, KD avoids high-variance reward-based optimization and complex reward design by providing dense, informative per-token targets, which typically yields faster convergence and simpler scaling.
+
+Built on verl's Ray-based single-controller components, we initially assembled a strictly on-policy KD pipeline where rollout generation, teacher knowledge acquisition, and policy optimization ran in lockstep. In practice, this synchronous design proved highly inefficient: the three stages had to wait for one another, creating pipeline bubbles and underutilized GPUs. To address this, we extend the asynchronous schedulers introduced by the One-Step-Off Policy pipeline to overlap these phases. This overlap preserves the same distillation objective while trading some strict on-policy guarantees for substantial gains in end-to-end throughput and hardware utilization.
+
+## 2. What This Recipe Adds
+
+This recipe is a direct fork of the original `recipe/gkd` with the following additions and modifications:
+
+### 2.1 Ascend NPU Adaptation
+
+To run GKD training on Ascend NPUs, the following key adaptations were made:
+
+- **Device auto-detection**: `main_gkd.py` calls `auto_set_ascend_device_name(config)` to automatically set `config.trainer.device = npu` when running on Ascend hardware, so no manual config changes are needed.
+- **HCCL communication backend**: `distributed_util.py` replaces NCCL with HCCL (via `vllm_ascend.distributed.device_communicators.pyhccl`) for weight synchronization between actor and rollout workers on NPU.
+- **NPU-aware weight sync group creation**: `ray_trainer.py` and `megatron_workers.py` use a separate weight-sync group creation path for NPU, bypassing the Ray collective group approach (which relies on NCCL) and instead using a direct IP/port-based stateless process group.
+- **Device name propagation**: All worker modules use `get_device_name()` (from `verl.utils.device`) instead of hardcoded `"cuda"`, ensuring tensors and autocast operations target the correct device.
+
+### 2.2 Teacher vLLM API Backend
+
+The original GKD recipe only supports an embedded vLLM engine as the teacher backend, which requires loading the teacher model into a worker process. This recipe adds a **vLLM API backend** (`vllm_api`) that connects to an existing vLLM serve API server via its OpenAI-compatible completions API, instead of embedding the vLLM engine in the worker:
+
+- **`teacher/vllm_api_backend.py`**: Implements `VLLMAPIBackend` class that connects to an external `vllm serve` instance, retrieves top-k logprobs through the completions API, and handles batch splitting to avoid OOM on the vLLM server side.
+- **`teacher/start_server_vllm_api.sh`**: Startup script for the API backend mode — first waits for the vLLM serve API to be ready, then launches the proxy and worker with `--backend vllm_api`.
+- **`teacher/worker.py`**: Extended to support `--backend vllm_api` with `--api-base` and `--serve-model` arguments alongside the original `--backend vllm_engine`.
+
+This is particularly useful on Ascend NPU where vLLM-Ascend is deployed as a standalone inference service, or when the teacher model is already running as a shared API server that multiple training jobs can consume simultaneously.
+
+### 2.3 FSDP/FSDP2 Backend Support
+
+The original GKD recipe only supports the Megatron training backend. This recipe adds a full FSDP/FSDP2 backend alongside Megatron, enabling users who prefer FSDP's simpler deployment model or who are working with models not yet supported by Megatron:
+
+- **`fsdp_workers.py`**: Implements `FSDPOnPolicyDistillActorWorker` and `FSDPOnPolicyDistillRolloutWorker`, reusing the disaggregated weight-sync path from `recipe.one_step_off_policy.fsdp_workers` and overriding `update_actor` / `async_generate_sequences` for the KD objective.
+- **`fsdp_kl_loss.py`**: FSDP-adapted version of the KL distillation loss. Since FSDP does not shard the vocab dimension across tensor-parallel ranks, the logits tensor on every rank already contains the full vocab dimension, allowing standard softmax / KL computation directly (no vocab-parallel cross-entropy needed).
+- **Dual config files**: `config/on_policy_distill_trainer.yaml` (FSDP) and `config/on_policy_distill_megatron_trainer.yaml` (Megatron) provide separate Hydra configurations for each backend.
+- **Backend selection**: `main_gkd.py`'s `create_role_worker_mapping()` dispatches to the correct worker classes based on `actor_rollout_ref.actor.strategy` (`megatron`, `fsdp`, or `fsdp2`).
+
+## 3. Distillation Overview and Objective
+
+This recipe centers on on-policy knowledge distillation: the student policy learns from a stronger teacher on samples generated by the current policy (on-policy). For each input prompt, the student (actor) generates responses; the teacher provides top-k token distributions, and the student is trained to match them token-wise.
+
+Core components:
+
+1. Teacher signal: top-k log-probabilities and token indices per valid token position.
+2. Student objective: sparse, token-level KL divergence between student logits and teacher top-k distribution.
+
+Objective: encourage student probabilities $Q$ to cover teacher modes $P$ using token-wise $\mathrm{KL}(P\,\|\,Q)$ computed on the teacher's top-k support.
+
+## 4. Efficient System Design
+
+### 4.1 Schedulers (One-Step / Two-Step Off-Policy)
+
+The native (serial) on-policy distillation process is shown in the figure below.
+
+![Zero-Step-Off Scheduler](https://raw.githubusercontent.com/eric-haibin-lin/verl-community/refs/heads/main/docs/zero-step-off-distill.png)
+
+This recipe supports optional schedulers that overlap generation, teacher querying, and updates to improve throughput without changing the distillation objective.
+
+#### 4.1.1 One-Step-Off-Policy
+
+![One-Step-Off Scheduler](https://raw.githubusercontent.com/eric-haibin-lin/verl-community/refs/heads/main/docs/one-step-off-distill.png)
+
+- Warm-up: 2 steps.
+- Overlap pattern: rollout while actor update; weight sync while teacher retrieving.
+- Timing keys: `sync_rollout_weights`, `wait_prev_gen`, `wait_prev_teacher`.
+
+#### 4.1.2 Two-Step-Off-Policy
+
+![Two-Step-Off Scheduler](https://raw.githubusercontent.com/eric-haibin-lin/verl-community/refs/heads/main/docs/two-step-off-distill.png)
+
+- Warm-up: 3 steps.
+- Overlap pattern: rollout, actor update while teacher retrieving; interleave weight sync.
+- Timing keys: `sync_rollout_weights`, `max(wait_prev_gen, wait_prev_prev_teacher)`.
+
+Tip: Use `two_step_off` when teacher takes much more time than sync; `one_step_off` for simpler overlapping.
+
+### 4.2 Weights sync between actor and rollout
+
+We initially followed the weight synchronization path from the One-Step-Off-Policy recipe (Ray collective broadcast across all actor and rollout ranks, plus Megatron-side allgather of parameter shards). In practice this became the dominant bottleneck, so we made three changes:
+
+1. Batch-and-bulk load on the rollout side: instead of streaming tensors one-by-one, we stage a bundle of parameter tensors and issue a single batched load into the rollout engine.
+2. Batch-and-bulk broadcast between the actor and rollout: instead of streaming tensors one-by-one, we stage a bundle of parameter tensors and issue a single batched broadcast between the actor and rollout workers.
+3. Replace allgather with gather-to-root in Megatron: parameter shards are gathered to actor rank 0, and that root serves as the single source for broadcasting to rollout ranks.
+
+## 5. High-Level Data & Control Flow
+
+```
+Driver (TaskRunner)
+  ├─ Initialize Ray, tokenizer, datasets, worker groups
+  ├─ Build ResourcePoolManager (actor vs rollout GPU/NPU layouts)
+  ├─ Trainer.fit()
+      ├─ init_workers(): build actor + rollout groups, broadcast weight metadata,
+      │   create weight-sync group (NCCL on GPU, HCCL on NPU)
+      ├─ continuous_iterator(): epochs → batches
+      ├─ scheduler (see Section 4)
+        • _async_gen_next_batch(): optional weight sync + non-blocking rollout
+        • _async_get_teacher_knowledge(): submit teacher requests, store future
+        ├─ For each step:
+            • Sync rollout weights
+            • Retrieve (batch, gen_output, teacher_output) from futures
+            • Merge gen + teacher outputs → DataProto
+            • Compute metrics (response length stats, timing, throughput)
+            • Update actor (forward_backward_batch + KL loss + optimizer step)
+            • (Optional) save checkpoint
+```
+
+## 6. Key Components
+
+### 6.1 `OnPolicyDistillTrainer` (`ray_trainer.py`)
+- Creates `GenerationBatchFuture` objects holding rollout and teacher futures.
+- Adds scheduling + teacher integration + modified metric emission (KL, timing, MFU).
+- NPU-aware weight-sync group creation using HCCL instead of NCCL.
+
+### 6.2 Actor Worker (Megatron backend)
+- `MegatronOnPolicyDistillActorWorker.update_policy()` orchestrates micro-batch forward/backward.
+- KL Loss injection via `logits_processor` during forward on pipeline last stage.
+
+### 6.3 Actor Worker (FSDP backend)
+- `FSDPOnPolicyDistillActorWorker.update_actor()` performs KL distillation update with FSDP-sharded model.
+- Uses `fsdp_kl_loss.py` for KL computation on full vocab logits.
+
+### 6.4 Rollout Worker (vLLM)
+- Pure inference mode (`init_model` builds model; no optimizer).
+- `async_generate_sequences` returns a Ray future for overlapping.
+
+### 6.5 Teacher Service (`teacher/`)
+- Proxy + worker architecture (ZMQ REQ/REP) for batched top-k retrieval.
+- `TeacherClient.submit()` returns a `Future`; aggregator composes micro-batches.
+- Configurable temperature, max tokens, only-response mode.
+- Two backend modes:
+  - **`vllm_engine`** (original): Embeds a vLLM engine instance in the worker process. Use `start_server_vllm_engine.sh` to launch.
+  - **`vllm_api`** (new): Connects to an existing vLLM serve API server via OpenAI-compatible completions API. Use `start_server_vllm_api.sh` to launch.
+
+### 6.6 KL Loss
+- **Megatron** (`megatron_kl_loss.py`): Performs normalization & stable per-token probability construction across TP shards. Gradient is (student_probs - teacher_sparse_probs) scaled by upstream grad.
+- **FSDP** (`fsdp_kl_loss.py`): Direct softmax / KL on full vocab logits (no TP vocab sharding needed).
+
+### 6.7 Distributed Utility (`distributed_util.py`)
+- `vllm_stateless_init_process_group()` selects NCCL or HCCL backend based on `is_npu_available`.
+
+## 7. Configuration Highlights
+
+### FSDP backend (`on_policy_distill_trainer.yaml`)
+
+| Section | Purpose | Notable Keys |
+|---------|---------|-------------|
+| actor_rollout_ref.actor.strategy | Backend selection | `fsdp` or `fsdp2` |
+| actor_rollout_ref.teacher | Teacher server | server_ip, server_port, n_server_workers |
+| actor_rollout_ref.actor.fsdp_config | FSDP settings | model_dtype, param_offload, optimizer_offload |
+| trainer | Global training control | total_epochs, save_freq, scheduler, device (`npu` on Ascend) |
+| rollout | Resource split for rollout | n_gpus_per_node, nnodes |
+
+### Megatron backend (`on_policy_distill_megatron_trainer.yaml`)
+
+| Section | Purpose | Notable Keys |
+|---------|---------|-------------|
+| actor_rollout_ref.actor.megatron | Megatron parallelism | pipeline_model_parallel_size, tensor_model_parallel_size, expert_model_parallel_size |
+| actor_rollout_ref.teacher | Teacher server | server_ip, server_port, n_server_workers |
+| trainer | Global training control | total_epochs, save_freq, scheduler, device (`npu` on Ascend) |
+| rollout | Resource split for rollout | n_gpus_per_node, nnodes |
+
+**Remember to set `trainer.n_gpus_per_node`, `trainer.nnodes`, `rollout.n_gpus_per_node` and `rollout.nnodes` to allocate NPU resources. On Ascend, `trainer.device` should be set to `npu`.**
+
+## 8. Usage Examples
+
+### 8.1 Environment Setup
+
+For setting up the Ascend NPU environment for verl, please refer to [ascend_quick_start.rst (in Chinese)](../../docs/ascend_tutorial/ascend_quick_start.rst).
+
+Key dependencies:
+- torch_npu (matching PyTorch version)
+- vllm + vllm-ascend (for rollout on NPU)
+- CANN toolkit
+- MindSpeed + Megatron-LM (for Megatron backend only)
+
+### 8.2 Launch Teacher Server
+
+Before training, you need a teacher server to provide logp information. The teacher service supports two backend modes:
+
+#### vLLM Engine backend (embedded)
+
+Launches a vLLM engine inside the worker process. The teacher model is loaded directly by the worker.
+
+```bash
+cd recipe/gkd_ascend/teacher
+bash start_server_vllm_engine.sh
+```
+
+You can also start a multi-node teacher server: start the main node using `start_server_vllm_engine.sh`, then start slave nodes using `join_server_vllm_engine.sh` (remember to set `$PROXY_IP` and `$PROXY_BACKEND_PORT` of the main node).
+
+#### vLLM API backend (remote serve)
+
+Connects to an existing vLLM serve API server. Start the vLLM server separately first:
+
+```bash
+vllm serve Qwen/Qwen2.5-72B --tensor-parallel-size 8 --port 8000
+```
+
+Then launch the teacher worker connecting to it:
+
+```bash
+cd recipe/gkd_ascend/teacher
+bash start_server_vllm_api.sh
+```
+
+In `start_server_vllm_api.sh`, configure `MODEL_API` (the vLLM serve URL, e.g. `http://0.0.0.0:8000`) and `SERVE_MODEL_NAME`.
+
+Verify the teacher server is reachable with:
+
+```bash
+telnet localhost 15555
+```
+
+### 8.3 FSDP Backend (Qwen3-4B Example)
+
+```bash
+export BACKEND=fsdp2
+bash run_4b_fsdp.sh
+```
+
+Or run directly:
+
+```bash
+python3 -u -m main_gkd --config-path=config --config-name on_policy_distill_trainer \
+    data.train_files=openai-gsm8k/train.parquet \
+    data.val_files=openai-gsm8k/test.parquet \
+    actor_rollout_ref.actor.strategy=fsdp \
+    actor_rollout_ref.model.path=/path/to/Qwen3-4B/ \
+    actor_rollout_ref.teacher.server_ip=127.0.0.1 \
+    actor_rollout_ref.teacher.server_port=15555 \
+    trainer.device=npu \
+    trainer.n_gpus_per_node=4 rollout.n_gpus_per_node=2 \
+    trainer.scheduler=one_step_off
+```
+
+### 8.4 Megatron Backend (Qwen3-4B Example)
+
+```bash
+export BACKEND=megatron
+bash run_4b_megatron.sh
+```
+
+Or run directly:
+
+```bash
+python3 -m main_gkd --config-path=config --config-name on_policy_distill_megatron_trainer \
+    data.train_files=openai-gsm8k/train.parquet \
+    data.val_files=openai-gsm8k/test.parquet \
+    actor_rollout_ref.model.path=/path/to/Qwen3-4B/ \
+    actor_rollout_ref.teacher.server_ip=127.0.0.1 \
+    actor_rollout_ref.teacher.server_port=15555 \
+    trainer.device=npu \
+    trainer.n_gpus_per_node=4 rollout.n_gpus_per_node=2 \
+    trainer.scheduler=one_step_off
+```
+
+## 9. Metrics & Monitoring
+
+Emitted metrics include (prefixes may vary):
+
+- Timing: `timing/wait_prev_gen`, `timing/sync_rollout_weights`, `timing/get_teacher_knowledge`, `timing/update_actor`.
+- Sequence stats: `response_seq_len/*` (avg, max, min, counts).
+- Performance: `perf/mfu/actor`, `perf/max_memory_allocated_gb`, `perf/cpu_memory_used_gb`.
+- Distillation: `actor/kl_loss`, `actor/grad_norm`, `actor/lr`.
+
+Interpretation Tips:
+
+- High `wait_prev_teacher` → scale `n_server_workers` and allocate more teacher NPUs or reduce per-request batch size, or just use `two_step_off`.
+- High `wait_prev_gen` with uniform lengths → allocate more rollout NPUs.
+- High `sync_rollout_weights` → check HCCL env / network congestion and try to modify `actor_rollout_ref.rollout.update_weights_bucket_megabytes`.
+
+## 10. Functional Support Summary
+
+| Category | Supported |
+|----------|-----------|
+| Train engine | Megatron, FSDP, FSDP2 |
+| Rollout engine | vLLM (via vLLM-Ascend on NPU) |
+| Hardware | Ascend NPU, NVIDIA GPU |
+| Teacher backend | vLLM engine (embedded), vLLM API (remote serve) |
+| Distillation signal | Teacher top-k logprobs & indices |
+| Scheduling | one_step_off, two_step_off |
+
+## 11. Quick Checklist Before Running
+
+- Ascend NPU environment set up (CANN, torch_npu, vllm-ascend installed).
+- Teacher server reachable (`telnet <ip> <port>`).
+- `actor_rollout_ref.model.path` contains the correct model config artifacts.
+- `train_files` points to a parquet dataset compatible with this recipe's dataset loader.
+- `trainer.device` set to `npu` (auto-detected by `auto_set_ascend_device_name`).
+- HCCL environment vars set for multi-node communication.

--- a/gkd_ascend/README.md
+++ b/gkd_ascend/README.md
@@ -202,7 +202,7 @@ You can also start a multi-node teacher server: start the main node using `start
 Connects to an existing vLLM serve API server. Start the vLLM server separately first:
 
 ```bash
-vllm serve Qwen/Qwen2.5-72B --tensor-parallel-size 8 --port 8000
+vllm serve Qwen/Qwen3-32B --tensor-parallel-size 4 --port 8000 --max-logprobs 256
 ```
 
 Then launch the teacher worker connecting to it:

--- a/gkd_ascend/REQUIRED_VERL.txt
+++ b/gkd_ascend/REQUIRED_VERL.txt
@@ -1,0 +1,3 @@
+VERL_COMMIT=56d18ec631dcb125c7818ad381886aefd761ae23
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@56d18ec631dcb125c7818ad381886aefd761ae23
+GIT_SETUP=git clone https://github.com/verl-project/verl.git && cd verl && git checkout 56d18ec631dcb125c7818ad381886aefd761ae23

--- a/gkd_ascend/agent_loop.py
+++ b/gkd_ascend/agent_loop.py
@@ -1,0 +1,64 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import logging
+import os
+
+import ray
+
+from verl.experimental.agent_loop.agent_loop import AgentLoopManager
+from verl.protocol import DataProto
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class GKDAgentLoopManager(AgentLoopManager):
+    async def generate_sequences_async(self, prompts: DataProto) -> DataProto:
+        """Split input batch and dispatch to agent loop workers (async version).
+
+        Args:
+            prompts (DataProto): Input batch.
+
+        Returns:
+            DataProto: Output batch.
+        """
+
+        chunkes = prompts.chunk(len(self.agent_loop_workers))
+        # Use asyncio.gather with ray.get wrapped in asyncio.to_thread to avoid blocking
+        import asyncio
+
+        outputs = await asyncio.gather(
+            *[
+                asyncio.to_thread(ray.get, worker.generate_sequences.remote(chunk))
+                for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=True)
+            ]
+        )
+        output = DataProto.concat(outputs)
+
+        # calculate performance metrics
+        metrics = [output.meta_info.pop("metrics") for output in outputs]  # List[List[Dict[str, str]]]
+        timing = self._performance_metrics(metrics, output)
+
+        output.meta_info = {"timing": timing, **outputs[0].meta_info}
+        return output
+
+    async def wake_up(self):
+        await asyncio.gather(*[replica.wake_up() for replica in self.rollout_replicas])
+
+    async def sleep(self):
+        await asyncio.gather(*[replica.sleep() for replica in self.rollout_replicas])
+
+    async def clear_kv_cache(self):
+        await asyncio.gather(*[replica.clear_kv_cache() for replica in self.rollout_replicas])

--- a/gkd_ascend/config/on_policy_distill_megatron_trainer.yaml
+++ b/gkd_ascend/config/on_policy_distill_megatron_trainer.yaml
@@ -1,0 +1,26 @@
+hydra:
+  searchpath:
+    - file://verl/trainer/config
+
+defaults:
+  - ppo_megatron_trainer
+  - _self_
+
+# config for the rollout (only for resource isolation)
+rollout:
+  # Number of nodes used in the rollout
+  nnodes: 1
+  # Number of GPUs per node
+  n_gpus_per_node: 8
+
+actor_rollout_ref:
+  hybrid_engine: False
+
+  teacher:
+    server_ip: localhost
+    server_port: 15555
+    overlap_rollout: False
+    n_server_workers: 1
+
+trainer:
+  scheduler: one_step_off

--- a/gkd_ascend/config/on_policy_distill_trainer.yaml
+++ b/gkd_ascend/config/on_policy_distill_trainer.yaml
@@ -1,0 +1,26 @@
+hydra:
+  searchpath:
+    - file://verl/trainer/config
+
+defaults:
+  - ppo_trainer
+  - _self_
+
+# config for the rollout (only for resource isolation)
+rollout:
+  # Number of nodes used in the rollout
+  nnodes: 1
+  # Number of GPUs per node
+  n_gpus_per_node: 8
+
+actor_rollout_ref:
+  hybrid_engine: False
+
+  teacher:
+    server_ip: localhost
+    server_port: 15555
+    overlap_rollout: False
+    n_server_workers: 1
+
+trainer:
+  scheduler: one_step_off

--- a/gkd_ascend/distributed_util.py
+++ b/gkd_ascend/distributed_util.py
@@ -1,0 +1,41 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl.utils.device import is_npu_available
+
+
+def vllm_stateless_init_process_group(master_address, master_port, rank, world_size, device):
+    """
+    vLLM provides `StatelessProcessGroup` to create a process group
+    without considering the global process group in torch.distributed.
+    It is recommended to create `StatelessProcessGroup`, and then initialize
+    the data-plane communication (NCCL) between external (train processes)
+    and vLLM workers.
+    """
+    # NOTE: If it is necessary to support weight synchronization with the sglang backend in the future,
+    # the following can be used:
+    # from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+    # from sglang.srt.distributed.utils import statelessprocessgroup
+    if is_npu_available:
+        from vllm_ascend.distributed.device_communicators.pyhccl import (
+            PyHcclCommunicator as PyNcclCommunicator,
+        )
+    else:
+        from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from vllm.distributed.utils import StatelessProcessGroup
+
+    pg = StatelessProcessGroup.create(host=master_address, port=master_port, rank=rank, world_size=world_size)
+    pynccl = PyNcclCommunicator(pg, device=device)
+    return pynccl

--- a/gkd_ascend/fsdp_kl_loss.py
+++ b/gkd_ascend/fsdp_kl_loss.py
@@ -30,9 +30,9 @@ import torch
 
 
 def topk_kl_divergence(
-  logits: torch.Tensor,
-  teacher_topk_logps: torch.Tensor,
-  teacher_topk_indices: torch.Tensor,
+    logits: torch.Tensor,
+    teacher_topk_logps: torch.Tensor,
+    teacher_topk_indices: torch.Tensor,
 ) -> torch.Tensor:
     """Compute the per-token KL(P||Q) loss restricted to the teacher's top-k.
 
@@ -47,8 +47,7 @@ def topk_kl_divergence(
         Per-token KL loss with shape ``logits.shape[:-1]``.
     """
     assert logits.shape[:-1] == teacher_topk_logps.shape[:-1], (
-        f"logits/teacher_topk_logps leading dims mismatch: "
-        f"{logits.shape} vs {teacher_topk_logps.shape}"
+        f"logits/teacher_topk_logps leading dims mismatch: {logits.shape} vs {teacher_topk_logps.shape}"
     )
     assert teacher_topk_logps.shape == teacher_topk_indices.shape, (
         f"teacher_topk_logps/teacher_topk_indices shape mismatch: "

--- a/gkd_ascend/fsdp_kl_loss.py
+++ b/gkd_ascend/fsdp_kl_loss.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""FSDP-adapted version of the KL distillation loss.
+
+Key difference between FSDP and Megatron: FSDP does not shard the vocab
+dimension across tensor-parallel ranks, so the logits tensor on every rank
+already contains the full vocab dimension. We can therefore run the standard
+softmax / KL directly. The semantics are kept consistent with
+``recipe.gkd.megatron_kl_loss.vocab_parallel_kl_divergence``:
+
+* Use KL(P||Q), where P is the teacher (target) and Q is the student (source).
+* Only compute on the top-k indices provided by the teacher (top-k distillation).
+* The output is a per-token loss with shape equal to ``logits.shape[:-1]``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def topk_kl_divergence(
+  logits: torch.Tensor,
+  teacher_topk_logps: torch.Tensor,
+  teacher_topk_indices: torch.Tensor,
+) -> torch.Tensor:
+    """Compute the per-token KL(P||Q) loss restricted to the teacher's top-k.
+
+    Args:
+        logits: Student model logits with shape ``(..., vocab_size)``.
+        teacher_topk_logps: Teacher model log-probabilities on the top-k
+            indices, with shape ``(..., top_k)``.
+        teacher_topk_indices: Vocab indices corresponding to the teacher's
+            top-k entries, with shape ``(..., top_k)`` and dtype ``long``.
+
+    Returns:
+        Per-token KL loss with shape ``logits.shape[:-1]``.
+    """
+    assert logits.shape[:-1] == teacher_topk_logps.shape[:-1], (
+        f"logits/teacher_topk_logps leading dims mismatch: "
+        f"{logits.shape} vs {teacher_topk_logps.shape}"
+    )
+    assert teacher_topk_logps.shape == teacher_topk_indices.shape, (
+        f"teacher_topk_logps/teacher_topk_indices shape mismatch: "
+        f"{teacher_topk_logps.shape} vs {teacher_topk_indices.shape}"
+    )
+
+    # Compute the student log-softmax once over the full vocab to avoid
+    # repeated logsumexp evaluations.
+    student_logps = torch.nn.functional.log_softmax(logits.float(), dim=-1)
+
+    # Gather the student log-probs at the teacher's top-k indices; the
+    # resulting shape equals ``teacher_topk_logps``.
+    student_topk_logps = torch.gather(
+        student_logps,
+        dim=-1,
+        index=teacher_topk_indices.long(),
+    )
+
+    teacher_topk_logps = teacher_topk_logps.to(student_topk_logps.dtype)
+    teacher_topk_probs = torch.exp(teacher_topk_logps)
+
+    # KL(P||Q) = sum_k P_k * (log P_k - log Q_k)
+    per_token_kl = torch.sum(
+        teacher_topk_probs * (teacher_topk_logps - student_topk_logps),
+        dim=-1,
+    )
+    return per_token_kl

--- a/gkd_ascend/fsdp_workers.py
+++ b/gkd_ascend/fsdp_workers.py
@@ -36,27 +36,27 @@ import os
 import numpy as np
 import torch
 import torch.distributed
+from fsdp_kl_loss import topk_kl_divergence
 from omegaconf import DictConfig, OmegaConf
 from ray.util.collective import collective
+from recipe.one_step_off_policy.distributed_util import vllm_stateless_init_process_group
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-from fsdp_kl_loss import topk_kl_divergence
-
-from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker
 from verl import DataProto
 from verl.single_controller.base.decorator import (
     Dispatch,
     make_nd_compute_dataproto_dispatch_fn,
     register,
 )
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from verl.utils import hf_processor, hf_tokenizer
+from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_device_id, get_device_name, get_torch_device
+from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import (
     fsdp_version,
     load_fsdp_model_to_gpu,
     offload_fsdp_model_to_cpu,
 )
-
-from verl.utils.ray_utils import get_event_loop
 from verl.utils.import_utils import import_external_libs
 from verl.utils.profiler import (
     DistProfiler,
@@ -66,14 +66,12 @@ from verl.utils.profiler import (
 )
 from verl.utils.profiler.performance import gather_timing
 from verl.utils.py_functional import append_to_dict
+from verl.utils.ray_utils import get_event_loop
 from verl.utils.seqlen_balancing import prepare_dynamic_batch
 from verl.utils.torch_dtypes import PrecisionType
-from recipe.one_step_off_policy.distributed_util import vllm_stateless_init_process_group
-from verl.utils.fs import copy_to_local
-from verl.utils.config import omega_conf_to_dataclass
-from verl.utils import hf_processor, hf_tokenizer
-from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.actor import DataParallelPPOActor
+from verl.workers.config import HFModelConfig, RolloutConfig
+from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker
 from verl.workers.rollout import get_rollout_class
 
 logger = logging.getLogger(__file__)
@@ -326,9 +324,7 @@ class _GKDFSDPDistillActor(DataParallelPPOActor):
             if masked_logits.numel() == 0:
                 kl_loss = logits_fp32.sum() * 0.0  # keep the grad graph
             else:
-                per_token_kl = topk_kl_divergence(
-                    masked_logits, masked_teacher_logps, masked_teacher_indices
-                )
+                per_token_kl = topk_kl_divergence(masked_logits, masked_teacher_logps, masked_teacher_indices)
                 kl_loss = per_token_kl.mean()
 
             (kl_loss * loss_scale).backward()
@@ -357,9 +353,7 @@ class FSDPOnPolicyDistillActorWorker(DetachSync):
     def __init__(self, config: DictConfig, role: str = "actor", **kwargs):
         _ensure_required_actor_rollout_fields(config)
         super().__init__(config=config, role=role, **kwargs)
-        assert self._is_actor and not self._is_rollout, (
-            "FSDPOnPolicyDistillActorWorker must be actor-only."
-        )
+        assert self._is_actor and not self._is_rollout, "FSDPOnPolicyDistillActorWorker must be actor-only."
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
@@ -477,13 +471,11 @@ class FSDPOnPolicyDistillRolloutWorker(DetachSync):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
-
         from torch.distributed.device_mesh import init_device_mesh
 
         self.param_dtype = torch.bfloat16
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
-        override_model_config = OmegaConf.to_container(OmegaConf.create(self.config.model.get("override_config", {})))
 
         use_shm = self.config.model.get("use_shm", False)
         local_path = copy_to_local(self.config.model.path, use_shm=use_shm)
@@ -498,7 +490,7 @@ class FSDPOnPolicyDistillRolloutWorker(DetachSync):
             else:
                 self.tokenizer.chat_template = self.config.model.custom_chat_template
 
-        from verl.utils.model import get_generation_config, print_model_size, update_model_config
+        from verl.utils.model import get_generation_config
 
         self.generation_config = get_generation_config(local_path, trust_remote_code=trust_remote_code)
 

--- a/gkd_ascend/fsdp_workers.py
+++ b/gkd_ascend/fsdp_workers.py
@@ -1,0 +1,534 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+# Copyright 2025 Individual Contributor: Brilliant Hanabi, funrunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""FSDP/FSDP2 worker implementation for the GKD recipe.
+
+This file adds an FSDP backend to GKD, reusing the following two pieces of
+infrastructure:
+
+1. ``recipe.one_step_off_policy.fsdp_workers.DetachActorWorker`` /
+   ``DetachAsyncRolloutWorker`` -- already implements the disaggregated
+   weight-sync link between actor and rollout via ``ray.util.collective``;
+2. ``verl.workers.fsdp_workers.ActorRolloutRefWorker`` -- provides generic
+   capabilities such as FSDP model construction, checkpoint management,
+   profiler and offload.
+
+GKD has a different training objective from PPO (the former does KL
+distillation using teacher top-k logps, the latter uses policy gradient),
+so ``update_actor`` and ``async_generate_sequences`` are overridden here.
+"""
+
+import logging
+import os
+
+import numpy as np
+import torch
+import torch.distributed
+from omegaconf import DictConfig, OmegaConf
+from ray.util.collective import collective
+
+from fsdp_kl_loss import topk_kl_divergence
+
+from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker
+from verl import DataProto
+from verl.single_controller.base.decorator import (
+    Dispatch,
+    make_nd_compute_dataproto_dispatch_fn,
+    register,
+)
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
+from verl.utils.fsdp_utils import (
+    fsdp_version,
+    load_fsdp_model_to_gpu,
+    offload_fsdp_model_to_cpu,
+)
+
+from verl.utils.ray_utils import get_event_loop
+from verl.utils.import_utils import import_external_libs
+from verl.utils.profiler import (
+    DistProfiler,
+    GPUMemoryLogger,
+    log_gpu_memory_usage,
+    simple_timer,
+)
+from verl.utils.profiler.performance import gather_timing
+from verl.utils.py_functional import append_to_dict
+from verl.utils.seqlen_balancing import prepare_dynamic_batch
+from verl.utils.torch_dtypes import PrecisionType
+from recipe.one_step_off_policy.distributed_util import vllm_stateless_init_process_group
+from verl.utils.fs import copy_to_local
+from verl.utils.config import omega_conf_to_dataclass
+from verl.utils import hf_processor, hf_tokenizer
+from verl.workers.config import HFModelConfig, RolloutConfig
+from verl.workers.actor import DataParallelPPOActor
+from verl.workers.rollout import get_rollout_class
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+device_name = get_device_name()
+
+__all__ = [
+    "FSDPOnPolicyDistillActorWorker",
+    "FSDPOnPolicyDistillRolloutWorker",
+]
+
+
+def _ensure_required_actor_rollout_fields(config: DictConfig) -> None:
+    """Same as megatron_workers: fill in fields expected by the base class.
+
+    GKD does not use PPO's mini-batch / epoch / router_replay fields, but
+    ``ActorRolloutRefWorker.__init__`` still accesses them while normalizing
+    the config, so safe default values are provided here.
+    """
+    is_struct = OmegaConf.is_struct(config) or False
+    OmegaConf.set_struct(config, False)
+    try:
+        if OmegaConf.select(config, "actor") is not None:
+            actor_cfg = config.actor
+            if OmegaConf.select(actor_cfg, "ppo_mini_batch_size") is None:
+                actor_cfg.ppo_mini_batch_size = 1
+            if OmegaConf.select(actor_cfg, "ppo_epochs") is None:
+                actor_cfg.ppo_epochs = 1
+            if OmegaConf.select(actor_cfg, "router_replay") is None:
+                actor_cfg.router_replay = OmegaConf.create({"mode": "disabled"})
+            # The FSDP base class's _forward_micro_batch reads the following
+            # fields; providing default values is sufficient.
+            if OmegaConf.select(actor_cfg, "use_remove_padding") is None:
+                actor_cfg.use_remove_padding = False
+            if OmegaConf.select(actor_cfg, "use_fused_kernels") is None:
+                actor_cfg.use_fused_kernels = False
+            if OmegaConf.select(actor_cfg, "ulysses_sequence_parallel_size") is None:
+                actor_cfg.ulysses_sequence_parallel_size = 1
+        if OmegaConf.select(config, "rollout") is not None:
+            rollout_cfg = config.rollout
+            if OmegaConf.select(rollout_cfg, "n") is None:
+                rollout_cfg.n = 1
+    finally:
+        OmegaConf.set_struct(config, is_struct)
+
+
+def _to_tensor(value, *, dtype, device):
+    """Safely convert numpy / list / tensor fields in ``non_tensor_batch`` to a tensor on ``device``."""
+    if isinstance(value, torch.Tensor):
+        return value.to(device=device, dtype=dtype)
+    if isinstance(value, np.ndarray):
+        if value.dtype == object:
+            # Object array: comes from distributed aggregation or chunk; stack element-wise.
+            value = np.stack([np.asarray(x) for x in value], axis=0)
+        return torch.from_numpy(np.ascontiguousarray(value)).to(device=device, dtype=dtype)
+    # list / tuple of tensors
+    if isinstance(value, (list, tuple)) and len(value) > 0 and isinstance(value[0], torch.Tensor):
+        return torch.stack(list(value), dim=0).to(device=device, dtype=dtype)
+    return torch.as_tensor(value, dtype=dtype, device=device)
+
+
+class DetachSync(AsyncActorRolloutRefWorker):
+    def _get_actor_params(self):
+        pass
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
+    def create_weight_sync_group(self, master_address, master_port, rank_offset, world_size):
+        rank = torch.distributed.get_rank() + rank_offset
+        self._weight_sync_group = vllm_stateless_init_process_group(
+            master_address,
+            master_port,
+            rank,
+            world_size,
+            get_torch_device().current_device(),
+        )
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
+    def sync_rollout_weights(self):
+        assert (self._is_actor or self._is_rollout) and not self.config.hybrid_engine
+        assert hasattr(self, "_weights_info") and self._weights_info is not None
+
+        if self._is_actor and self._is_offload_param:
+            load_fsdp_model_to_gpu(self.actor_module_fsdp)
+        params = self._get_actor_params() if self._is_actor else None
+
+        rollout_name = self.config.rollout.name
+        if self._is_rollout:
+            if rollout_name == "vllm":
+                from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
+
+                inference_model = self.rollout.inference_engine.worker.model_runner.model
+                patch_vllm_moe_model_weight_loader(inference_model)
+            elif rollout_name == "sglang":
+                inference_model = self.rollout._engine
+            else:
+                raise NotImplementedError(f"Unknown rollout name: {rollout_name}")
+        loop = get_event_loop()
+        for key, shape, dtype in self._weights_info:
+            tensor = torch.empty(shape, dtype=dtype, device=get_torch_device().current_device())
+            if self._is_actor:
+                assert key in params
+                origin_data = params[key]
+                if hasattr(origin_data, "full_tensor"):
+                    origin_data = origin_data.full_tensor()
+                if torch.distributed.get_rank() == 0:
+                    tensor.copy_(origin_data)
+
+            if device_name == "npu":
+                self._weight_sync_group.broadcast(tensor, src=0, stream=get_torch_device().current_stream())
+            else:
+                collective.broadcast(tensor, src_rank=0, group_name="actor_rollout")
+
+            if self._is_rollout:
+                if rollout_name == "vllm":
+                    inference_model.load_weights([(key, tensor)])
+                elif rollout_name == "sglang":
+                    # first_rank_in_node = self._tp_rank % tp_size_per_node == 0，
+                    # Only the first rank within each node (i.e., the local rank is 0) initializes the engine;
+                    # engines for other ranks are set to None.
+
+                    if inference_model is not None:
+                        loop.run_until_complete(self.update_weights(inference_model, [(key, tensor)]))
+
+        if self._is_actor and self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.actor_module_fsdp)
+        get_torch_device().empty_cache()
+
+    async def update_weights(self, inference_engine, params):
+        from sglang.srt.weight_sync.utils import update_weights as sgl_update_weights
+
+        await sgl_update_weights(
+            engine=inference_engine,
+            params_batch=params,
+            device_mesh_key="infer_tp",
+            device_mesh=self.rollout_device_mesh,
+        )
+
+        if self.rollout_device_mesh["infer_tp"].get_local_rank() == 0:
+            await inference_engine.flush_cache()
+
+
+class _GKDFSDPDistillActor(DataParallelPPOActor):
+    """GKD KL-distillation training step under FSDP.
+
+    This is a lightweight trainer: it directly runs a forward on
+    ``actor_module`` to obtain the full logits and computes KL(P||Q) on the
+    teacher's top-k indices. It deliberately does not reuse
+    :class:`verl.workers.actor.dp_actor.DataParallelPPOActor`, because that
+    class hard-codes the PPO advantages / old_log_probs flow.
+    """
+
+    def __init__(self, config, actor_module, actor_optimizer):
+        super().__init__(config, actor_module, actor_optimizer)
+        self.param_dtype = PrecisionType.to_dtype(
+            config.fsdp_config.get("dtype", "bfloat16") if config.get("fsdp_config") else "bfloat16"
+        )
+        self.grad_clip = config.get("grad_clip", 1.0)
+
+    def _forward_logits(self, micro_batch):
+        """Run a single forward and return the full-sequence logits (used for alignment with the teacher tensor)."""
+        input_ids = micro_batch["input_ids"]
+        attention_mask = micro_batch["attention_mask"]
+        position_ids = micro_batch["position_ids"]
+
+        with torch.autocast(device_type=device_name, dtype=self.param_dtype):
+            output = self.actor_module(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                use_cache=False,
+            )
+
+        return output.logits  # (bs, seq_len, vocab)
+
+    @staticmethod
+    def _build_calc_kl_mask(micro_batch):
+        """Semantically identical to ``recipe.gkd.megatron_workers.forward_backward_batch``:
+
+        ``calc_kl_mask = attention_mask.clone()``
+        ``calc_kl_mask[:, :(-response_length - 1)] = False``
+
+        Only positions within ``[-response_length - 1 :]`` that are also true
+        in ``attention_mask`` are kept. KL is computed pointwise between the
+        student logits and the teacher top-k logps at those positions.
+        Returns a tensor of shape (B, S).
+        """
+        responses = micro_batch["responses"]
+        response_length = responses.size(-1)
+        calc_kl_mask = micro_batch["attention_mask"].clone().to(torch.bool)
+        if calc_kl_mask.size(1) > response_length + 1:
+            calc_kl_mask[:, : -(response_length + 1)] = False
+        return calc_kl_mask
+
+    def update_policy(self, data: DataProto) -> dict:
+        """Run KL-distillation forward / backward and an optimizer step on one mini-batch."""
+        self.actor_module.train()
+
+        select_keys = ["responses", "input_ids", "attention_mask", "position_ids"]
+        non_tensor_keys = ["teacher_topk_logps", "teacher_topk_indices"]
+        data = data.select(batch_keys=select_keys, non_tensor_batch_keys=non_tensor_keys)
+
+        use_dynamic_bsz = bool(self.config.get("use_dynamic_bsz", False))
+        if use_dynamic_bsz:
+            max_token_len = int(self.config.max_token_len)
+            micro_batches, _ = prepare_dynamic_batch(data, max_token_len=max_token_len)
+        else:
+            micro_batch_size = int(self.config.get("micro_batch_size", 1))
+            micro_batches = data.split(micro_batch_size)
+
+        n_micro_batch = max(len(micro_batches), 1)
+        loss_scale = 1.0 / n_micro_batch
+
+        metrics: dict = {}
+        self.actor_optimizer.zero_grad()
+
+        for micro_batch in micro_batches:
+            micro_batch = micro_batch.to(get_device_id())
+            model_inputs = {**micro_batch.batch, **micro_batch.non_tensor_batch}
+
+            # (B, S) boolean mask, keeping only positions in the prompt-tail +
+            # response range where the attention mask is active.
+            calc_kl_mask = self._build_calc_kl_mask(model_inputs)
+
+            logits = self._forward_logits(model_inputs)  # (B, S, V)
+            assert logits.shape[:2] == calc_kl_mask.shape, (
+                f"logits / mask shape mismatch: {logits.shape} vs {calc_kl_mask.shape}"
+            )
+            logits_fp32 = logits.float()
+
+            # teacher_topk_* are written into non_tensor_batch by
+            # teacher_utils.get_teacher_knowledge, with shape (B, S, topk),
+            # aligned positionally with logits.
+            teacher_topk_logps = _to_tensor(
+                model_inputs["teacher_topk_logps"], dtype=torch.float32, device=logits_fp32.device
+            )
+            teacher_topk_indices = _to_tensor(
+                model_inputs["teacher_topk_indices"], dtype=torch.long, device=logits_fp32.device
+            )
+            assert teacher_topk_logps.shape[:2] == calc_kl_mask.shape, (
+                f"teacher / mask shape mismatch: {teacher_topk_logps.shape} vs {calc_kl_mask.shape}"
+            )
+
+            # Same semantics as the megatron version: only compute KL where
+            # calc_kl_mask is true.
+            masked_logits = logits_fp32[calc_kl_mask]  # (n_valid, V)
+            masked_teacher_logps = teacher_topk_logps[calc_kl_mask]  # (n_valid, topk)
+            masked_teacher_indices = teacher_topk_indices[calc_kl_mask]  # (n_valid, topk)
+
+            if masked_logits.numel() == 0:
+                kl_loss = logits_fp32.sum() * 0.0  # keep the grad graph
+            else:
+                per_token_kl = topk_kl_divergence(
+                    masked_logits, masked_teacher_logps, masked_teacher_indices
+                )
+                kl_loss = per_token_kl.mean()
+
+            (kl_loss * loss_scale).backward()
+
+            append_to_dict(metrics, {"actor/kl_loss": kl_loss.detach().item()})
+
+        grad_norm = self._optimizer_step()
+        append_to_dict(
+            metrics,
+            {"actor/grad_norm": grad_norm.detach().item() if torch.is_tensor(grad_norm) else float(grad_norm)},
+        )
+
+        get_torch_device().empty_cache()
+        return metrics
+
+
+class FSDPOnPolicyDistillActorWorker(DetachSync):
+    """FSDP version of the GKD actor worker.
+
+    Inherits from ``DetachActorWorker`` to reuse its actor<->rollout
+    collective weight sync, then overrides the tail of ``init_model`` to
+    install GKD's own trainer, and overrides ``update_actor`` to run the
+    KL-distillation path.
+    """
+
+    def __init__(self, config: DictConfig, role: str = "actor", **kwargs):
+        _ensure_required_actor_rollout_fields(config)
+        super().__init__(config=config, role=role, **kwargs)
+        assert self._is_actor and not self._is_rollout, (
+            "FSDPOnPolicyDistillActorWorker must be actor-only."
+        )
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        # Go through the base class (ultimately verl's ActorRolloutRefWorker)
+        # to fully initialize the model / optimizer / checkpoint.
+        super().init_model()
+        # Replace self.actor with the GKD custom trainer to avoid triggering
+        # the PPO flow.
+
+        actor_cfg = omega_conf_to_dataclass(self.config.actor)
+        self.actor = _GKDFSDPDistillActor(
+            config=actor_cfg,
+            actor_module=self.actor_module_fsdp,
+            actor_optimizer=self.actor_optimizer,
+        )
+        log_gpu_memory_usage("After GKD FSDP actor init", logger=logger)
+
+    def _get_actor_params(self):
+        assert self._is_actor
+        params = self.actor_module_fsdp.state_dict()
+        from verl.utils.model import convert_weight_keys
+
+        params = convert_weight_keys(
+            params, getattr(self.actor_module_fsdp, "_fsdp_wrapped_module", self.actor_module_fsdp)
+        )
+        return params
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def get_actor_weights_info(self):
+        assert self._is_actor
+        if hasattr(self, "_weights_info"):
+            return self._weights_info
+        if fsdp_version(self.actor_module_fsdp) == 1:
+            from torch.distributed.fsdp.api import ShardedStateDictConfig, StateDictType
+
+            FSDP.set_state_dict_type(
+                self.actor_module_fsdp,
+                state_dict_type=StateDictType.SHARDED_STATE_DICT,
+                state_dict_config=ShardedStateDictConfig(),
+            )
+        params = self._get_actor_params()
+        ret = []
+        for key, tensor in params.items():
+            ret.append((key, tensor.size(), tensor.dtype))
+        self._weights_info = ret
+        return ret
+
+
+class FSDPOnPolicyDistillRolloutWorker(DetachSync):
+    """FSDP version of the GKD rollout worker.
+
+    Inherits from ``DetachAsyncRolloutWorker`` and already provides:
+    * ``set_actor_weights_info`` -- receives weight metadata from the actor side;
+    * ``sync_rollout_weights`` -- syncs actor weights to vllm/sglang via collective.broadcast;
+    * the rollout engine built by ``ActorRolloutRefWorker.__init__``.
+
+    GKD additionally needs a non-blocking ``async_generate_sequences`` and
+    attaches ``timing`` info during generation for the trainer to log; the
+    implementation of these two APIs is kept consistent with
+    ``recipe.gkd.megatron_workers.MegatronOnPolicyDistillRolloutWorker``.
+    """
+
+    # NOTE: the parent class ``DetachAsyncRolloutWorker.__init__`` only
+    # accepts (config, role); the same signature is strictly preserved here
+    # and no extra kwargs are accepted.
+    def __init__(self, config: DictConfig, role: str = "rollout"):
+        _ensure_required_actor_rollout_fields(config)
+        super().__init__(config=config, role=role)
+        assert self.role == "rollout"
+        assert self._is_rollout and not self._is_actor and not self._is_ref, (
+            "FSDPOnPolicyDistillRolloutWorker must be rollout-only."
+        )
+
+        from verl.utils.model import get_generation_config
+
+        self.local_path = copy_to_local(self.config.model.path)
+        self.generation_config = get_generation_config(self.local_path)
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="rollout"))
+    @GPUMemoryLogger(role="generate_sequences", logger=logger)
+    @DistProfiler.annotate(color="red")
+    def generate_sequences(self, prompts: DataProto):
+        prompts.batch = prompts.batch.to(get_device_name())
+        meta_info = {
+            "eos_token_id": self.generation_config.eos_token_id
+            if self.generation_config is not None
+            else self.tokenizer.eos_token_id,
+            "pad_token_id": self.generation_config.pad_token_id
+            if self.generation_config is not None
+            else self.tokenizer.pad_token_id,
+        }
+        prompts.meta_info.update(meta_info)
+
+        timing_generate: dict = {}
+        with simple_timer("generate_sequences", timing_generate):
+            output = self.rollout.generate_sequences(prompts=prompts)
+
+        timing_generate = gather_timing(timing_generate)
+        output.meta_info["timing"] = timing_generate
+        output = output.to("cpu")
+        get_torch_device().empty_cache()
+        return output
+
+    @register(
+        dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="rollout"),
+        blocking=False,
+    )
+    def async_generate_sequences(self, prompts: DataProto):
+        return self.generate_sequences(prompts)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def set_actor_weights_info(self, weights_info):
+        assert self._is_rollout
+        self._weights_info = weights_info
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+
+        from torch.distributed.device_mesh import init_device_mesh
+
+        self.param_dtype = torch.bfloat16
+        # This is used to import external_lib into the huggingface systems
+        import_external_libs(self.config.model.get("external_lib", None))
+        override_model_config = OmegaConf.to_container(OmegaConf.create(self.config.model.get("override_config", {})))
+
+        use_shm = self.config.model.get("use_shm", False)
+        local_path = copy_to_local(self.config.model.path, use_shm=use_shm)
+        trust_remote_code = self.config.model.get("trust_remote_code", False)
+
+        self.tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        self.processor = hf_processor(local_path, trust_remote_code=trust_remote_code)
+
+        if self.config.model.get("custom_chat_template", None) is not None:
+            if self.processor is not None:
+                self.processor.chat_template = self.config.model.custom_chat_template
+            else:
+                self.tokenizer.chat_template = self.config.model.custom_chat_template
+
+        from verl.utils.model import get_generation_config, print_model_size, update_model_config
+
+        self.generation_config = get_generation_config(local_path, trust_remote_code=trust_remote_code)
+
+        infer_tp = self.config.rollout.tensor_model_parallel_size
+        dp = self.world_size // infer_tp
+        assert self.world_size % infer_tp == 0, (
+            f"rollout world_size: {self.world_size} is not divisible by infer_tp: {infer_tp}"
+        )
+        rollout_device_mesh = init_device_mesh(
+            device_name, mesh_shape=(dp, infer_tp), mesh_dim_names=["dp", "infer_tp"]
+        )
+        self.rollout_device_mesh = rollout_device_mesh
+
+        is_collect = rollout_device_mesh["infer_tp"].get_local_rank() == 0
+        self._register_dispatch_collect_info(
+            "rollout", dp_rank=rollout_device_mesh["dp"].get_local_rank(), is_collect=is_collect
+        )
+
+        rollout_name = self.config.rollout.name
+        if rollout_name not in ("vllm", "sglang"):
+            raise NotImplementedError(f"rollout_name: {rollout_name} is not supported")
+
+        rollout_config: RolloutConfig = omega_conf_to_dataclass(self.config.rollout)
+        model_config: HFModelConfig = omega_conf_to_dataclass(self.config.model, dataclass_type=HFModelConfig)
+        self.model_config = model_config
+
+        log_gpu_memory_usage(f"Before building {rollout_name} rollout", logger=logger)
+        self.rollout = get_rollout_class(rollout_config.name, rollout_config.mode)(
+            config=rollout_config, model_config=model_config, device_mesh=rollout_device_mesh
+        )
+        log_gpu_memory_usage(f"After building {rollout_name} rollout", logger=logger)
+
+        get_torch_device().empty_cache()

--- a/gkd_ascend/main_gkd.py
+++ b/gkd_ascend/main_gkd.py
@@ -24,8 +24,8 @@ import hydra
 import ray
 
 from verl.trainer.ppo.ray_trainer import ResourcePoolManager
-from verl.utils.device import auto_set_ascend_device_name
 from verl.trainer.ppo.utils import Role
+from verl.utils.device import auto_set_ascend_device_name
 
 
 def create_resource_pool_manager(config, roles: list) -> ResourcePoolManager:
@@ -81,24 +81,24 @@ def create_role_worker_mapping(config):
     #   ``recipe.one_step_off_policy.fsdp_workers``.
     actor_strategy = config.actor_rollout_ref.actor.strategy
     if actor_strategy == "megatron":
-        from verl.single_controller.ray import RayWorkerGroup
-
         from megatron_workers import (
             MegatronOnPolicyDistillActorWorker,
             MegatronOnPolicyDistillRolloutWorker,
         )
+
+        from verl.single_controller.ray import RayWorkerGroup
 
         rollout_cls = MegatronOnPolicyDistillRolloutWorker
         actor_cls = MegatronOnPolicyDistillActorWorker
         ray_worker_group_cls = RayWorkerGroup
 
     elif actor_strategy in ("fsdp", "fsdp2"):
-        from verl.single_controller.ray import RayWorkerGroup
-
         from fsdp_workers import (
             FSDPOnPolicyDistillActorWorker,
             FSDPOnPolicyDistillRolloutWorker,
         )
+
+        from verl.single_controller.ray import RayWorkerGroup
 
         rollout_cls = FSDPOnPolicyDistillRolloutWorker
         actor_cls = FSDPOnPolicyDistillActorWorker
@@ -142,11 +142,11 @@ class TaskRunner:
 
         from omegaconf import OmegaConf
 
-        from verl.utils.fs import copy_to_local
-
         # Lazy import to avoid heavy deps (e.g. megatron) when only the entry
         # point is loaded for hydra config resolution.
         from ray_trainer import OnPolicyDistillTrainer
+
+        from verl.utils.fs import copy_to_local
 
         print(f"TaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
 
@@ -221,6 +221,7 @@ def main(config):
         config_dict: Hydra configuration dictionary containing training parameters.
     """
     from time import time
+
     from verl.trainer.main_ppo import run_ppo
 
     start_time = time()

--- a/gkd_ascend/main_gkd.py
+++ b/gkd_ascend/main_gkd.py
@@ -1,0 +1,236 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2025 Individual Contributor: Brilliant Hanabi, furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Note that we don't combine the main with ray_trainer as ray_trainer is used by other main.
+"""
+
+import asyncio
+import os
+import socket
+
+import hydra
+import ray
+
+from verl.trainer.ppo.ray_trainer import ResourcePoolManager
+from verl.utils.device import auto_set_ascend_device_name
+from verl.trainer.ppo.utils import Role
+
+
+def create_resource_pool_manager(config, roles: list) -> ResourcePoolManager:
+    """
+    Create resource pool manager
+
+    Args:
+        config: Configuration object
+        roles: List of roles that need to create resource pools
+
+    Returns:
+        ResourcePoolManager: Resource pool manager
+    """
+    resource_pool_spec = {}
+    mapping = {}
+
+    # Actor resource pool
+
+    assert config.trainer.n_gpus_per_node > 0, "config.trainer.n_gpus_per_node must be greater than 0"
+    assert config.trainer.nnodes > 0, "config.trainer.nnodes must be greater than 0"
+
+    trainer_pool = [config.trainer.n_gpus_per_node] * config.trainer.nnodes
+    resource_pool_spec["trainer_pool"] = trainer_pool
+
+    # Map training-related roles to the same resource pool
+    mapping[Role.Actor] = "trainer_pool"
+
+    # Rollout resource pool
+    assert config.rollout.n_gpus_per_node > 0, "config.rollout.n_gpus_per_node must be greater than 0"
+    assert config.rollout.nnodes > 0, "config.rollout.nnodes must be greater than 0"
+
+    rollout_pool = [config.rollout.n_gpus_per_node] * config.rollout.nnodes
+    resource_pool_spec["rollout_pool"] = rollout_pool
+    mapping[Role.Rollout] = "rollout_pool"
+
+    return ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
+
+
+def create_role_worker_mapping(config):
+    """
+    Create mapping from roles to worker classes
+
+    Args:
+        config: Configuration object
+
+    Returns:
+        dict: Mapping from roles to worker classes
+    """
+    # GKD now supports two backends:
+    # - "megatron": existing Megatron-LM split actor / rollout workers.
+    # - "fsdp" / "fsdp2": new FSDP / FSDP2 split actor / rollout workers,
+    #   reusing the disaggregated weight-sync path from
+    #   ``recipe.one_step_off_policy.fsdp_workers``.
+    actor_strategy = config.actor_rollout_ref.actor.strategy
+    if actor_strategy == "megatron":
+        from verl.single_controller.ray import RayWorkerGroup
+
+        from megatron_workers import (
+            MegatronOnPolicyDistillActorWorker,
+            MegatronOnPolicyDistillRolloutWorker,
+        )
+
+        rollout_cls = MegatronOnPolicyDistillRolloutWorker
+        actor_cls = MegatronOnPolicyDistillActorWorker
+        ray_worker_group_cls = RayWorkerGroup
+
+    elif actor_strategy in ("fsdp", "fsdp2"):
+        from verl.single_controller.ray import RayWorkerGroup
+
+        from fsdp_workers import (
+            FSDPOnPolicyDistillActorWorker,
+            FSDPOnPolicyDistillRolloutWorker,
+        )
+
+        rollout_cls = FSDPOnPolicyDistillRolloutWorker
+        actor_cls = FSDPOnPolicyDistillActorWorker
+        ray_worker_group_cls = RayWorkerGroup
+
+    else:
+        raise NotImplementedError(
+            f"Unsupported actor_rollout_ref.actor.strategy: {actor_strategy}. "
+            "Expected one of: 'megatron', 'fsdp', 'fsdp2'."
+        )
+
+    # Map roles to their corresponding remote worker classes.
+    role_worker_mapping = {
+        Role.Rollout: ray.remote(rollout_cls),
+        Role.Actor: ray.remote(actor_cls),
+    }
+
+    return role_worker_mapping, ray_worker_group_cls
+
+
+@ray.remote(num_cpus=10, max_concurrency=100)  # please make sure main_task is not scheduled on head
+class TaskRunner:
+    """Ray remote class for executing distributed PPO training tasks.
+
+    This class encapsulates the main training logic and runs as a Ray remote actor
+    to enable distributed execution across multiple nodes and GPUs.
+    """
+
+    def run(self, config):
+        """Execute the main PPO training workflow.
+
+        This method sets up the distributed training environment, initializes
+        workers, datasets, and reward functions, then starts the training process.
+
+        Args:
+            config: Training configuration object containing all parameters needed
+                   for setting up and running the PPO training process.
+        """
+        # Print the initial configuration. `resolve=True` will evaluate symbolic values.
+        from pprint import pprint
+
+        from omegaconf import OmegaConf
+
+        from verl.utils.fs import copy_to_local
+
+        # Lazy import to avoid heavy deps (e.g. megatron) when only the entry
+        # point is loaded for hydra config resolution.
+        from ray_trainer import OnPolicyDistillTrainer
+
+        print(f"TaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
+
+        pprint(OmegaConf.to_container(config, resolve=True))
+
+        OmegaConf.resolve(config)
+
+        # Download the checkpoint from HDFS to the local machine.
+        # `use_shm` determines whether to use shared memory, which could lead to faster model loading if turned on
+        local_path = copy_to_local(
+            config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False)
+        )
+
+        # Instantiate the tokenizer and processor.
+        from verl.utils import hf_processor, hf_tokenizer
+
+        trust_remote_code = config.data.get("trust_remote_code", False)
+        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        # Used for multimodal LLM, could be None
+        processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
+
+        # Version validation for vllm.
+        if config.actor_rollout_ref.rollout.name in ["vllm"]:
+            from verl.utils.vllm import is_version_ge
+
+            if config.actor_rollout_ref.model.get("lora_rank", 0) > 0:
+                if not is_version_ge(pkg="vllm", minver="0.7.3"):
+                    raise NotImplementedError("PPO LoRA is not supported before vllm 0.7.3")
+
+        role_worker_mapping, ray_worker_group_cls = create_role_worker_mapping(config)
+
+        resource_pool_manager = create_resource_pool_manager(config, role_worker_mapping.keys())
+
+        from verl.trainer.main_ppo import create_rl_sampler
+        from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
+
+        # Create training and validation datasets.
+        train_dataset = RLHFDataset(config.data.train_files, tokenizer, config.data, None)
+
+        if config.data.val_files:
+            val_dataset = RLHFDataset(config.data.val_files, tokenizer, config.data, None)
+        else:
+            val_dataset = None
+
+        train_sampler = create_rl_sampler(config.data, train_dataset)
+
+        # Initialize the PPO trainer.
+        trainer = OnPolicyDistillTrainer(
+            config=config,
+            tokenizer=tokenizer,
+            processor=processor,
+            role_worker_mapping=role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            collate_fn=collate_fn,
+            train_sampler=train_sampler,
+            device_name=config.trainer.device,
+        )
+        # Initialize the workers of the trainer.
+        trainer.init_workers()
+        # Start the training process.
+        asyncio.run(trainer.fit())
+
+
+@hydra.main(config_path="config", config_name="on_policy_distill_trainer", version_base=None)
+def main(config):
+    """Main entry point for PPO training with Hydra configuration management.
+
+    Args:
+        config_dict: Hydra configuration dictionary containing training parameters.
+    """
+    from time import time
+    from verl.trainer.main_ppo import run_ppo
+
+    start_time = time()
+
+    # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
+    auto_set_ascend_device_name(config)
+
+    run_ppo(config, task_runner_class=TaskRunner)
+    print(f"total time: {time() - start_time:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/gkd_ascend/megatron_kl_loss.py
+++ b/gkd_ascend/megatron_kl_loss.py
@@ -1,0 +1,161 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from megatron.core.fusions.fused_cross_entropy import calculate_logits_max
+from megatron.core.parallel_state import (
+    get_data_parallel_rank,
+    get_tensor_model_parallel_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from megatron.core.tensor_parallel.utils import VocabUtility
+
+
+def normalize(logps):
+    probs = torch.exp(logps)
+    probs = probs / probs.sum(dim=-1, keepdim=True)
+    normalized_logps = torch.log(probs)
+    return normalized_logps
+
+
+def mylog(message):
+    with open("kl_loss.log", "a") as f:
+        f.write(f"({get_data_parallel_rank()}, {get_tensor_model_parallel_rank()}): {message}\n")
+
+
+class _VocabParallelKLDivergence(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, vocab_parallel_logits, target_topk_logps, target_topk_indices):
+        # seq_len, batch_size, top_k = target_topk_logps.size()
+        # target_topk_logps = normalize(target_topk_logps)
+        vocab_parallel_logits, logits_max = calculate_logits_max(vocab_parallel_logits)
+        partition_vocab_size = vocab_parallel_logits.size(-1)
+
+        torch.distributed.all_reduce(
+            logits_max, op=torch.distributed.ReduceOp.MAX, group=get_tensor_model_parallel_group()
+        )
+
+        vocab_parallel_logits -= logits_max.unsqueeze(dim=-1)
+        vocab_parallel_logits.exp_()
+        exp_logits = vocab_parallel_logits
+        sum_exp_logits = exp_logits.sum(dim=-1)
+
+        torch.distributed.all_reduce(
+            sum_exp_logits,
+            op=torch.distributed.ReduceOp.SUM,
+            group=get_tensor_model_parallel_group(),
+        )
+
+        # Get the partition's vocab indices
+        rank = get_tensor_model_parallel_rank()
+        world_size = get_tensor_model_parallel_world_size()
+        vocab_start_index, vocab_end_index = VocabUtility.vocab_range_from_per_partition_vocab_size(
+            partition_vocab_size, rank, world_size
+        )
+
+        topk_indices_in_vocab_mask = (target_topk_indices >= vocab_start_index) & (
+            target_topk_indices < vocab_end_index
+        )
+
+        vocab_parallel_target_topk_indices = target_topk_indices - vocab_start_index
+        vocab_parallel_target_topk_indices[~topk_indices_in_vocab_mask] = 0
+        vocab_parallel_target_topk_probs = torch.exp(target_topk_logps)
+        vocab_parallel_target_topk_probs[~topk_indices_in_vocab_mask] = 0
+        vocab_parallel_target_topk_logps = torch.empty_like(target_topk_logps)
+        vocab_parallel_target_topk_logps[...] = target_topk_logps[...]
+        vocab_parallel_target_topk_logps[~topk_indices_in_vocab_mask] = 0
+        # assert ((0 <= target_topk_indices) & (target_topk_indices < partition_vocab_size)).all()
+
+        # bs, sl, topk = target_topk_indices.shape
+        target_topk_logps_origin_shape = target_topk_indices.shape
+        topk = target_topk_indices.size(-1)
+
+        vocab_parallel_source_probs = exp_logits
+        vocab_parallel_source_probs.div_(sum_exp_logits.unsqueeze(-1))
+        vocab_parallel_source_probs_2d = vocab_parallel_source_probs.view(-1, partition_vocab_size)  # (b*s, h/tp)
+
+        arange_1d = torch.arange(
+            start=0, end=vocab_parallel_source_probs_2d.size(0), device=vocab_parallel_source_probs_2d.device
+        )  # (b*s, )
+        vocab_parallel_source_topk_probs_2d = vocab_parallel_source_probs_2d[
+            arange_1d.unsqueeze(-1), vocab_parallel_target_topk_indices.view(-1, topk)
+        ]  # (b*s, topk)
+        vocab_parallel_source_topk_probs = vocab_parallel_source_topk_probs_2d.view(
+            target_topk_logps_origin_shape
+        )  # (b, s, topk)
+        vocab_parallel_source_topk_logps = torch.log(1e-20 + vocab_parallel_source_topk_probs)
+        vocab_parallel_source_topk_logps[~topk_indices_in_vocab_mask] = 0
+
+        # KL(P||Q)会强制 Q 覆盖 P 的所有模式（避免漏峰）
+        # KL(Q||P)会鼓励 Q 聚焦于 P 的一个模式（避免多峰)
+        # 这里使用 KL(P||Q)，其中P为target，Q为source，鼓励source学习target的所有模式
+
+        per_token_kl_loss = torch.sum(
+            vocab_parallel_target_topk_probs * (vocab_parallel_target_topk_logps - vocab_parallel_source_topk_logps),
+            dim=-1,
+        )  # (b, s)
+
+        # if torch.isinf(per_token_kl_loss).any() or torch.isnan(per_token_kl_loss).any():
+        #     breakpoint()
+
+        torch.distributed.all_reduce(
+            per_token_kl_loss,
+            op=torch.distributed.ReduceOp.SUM,
+            group=get_tensor_model_parallel_group(),
+        )
+
+        ctx.save_for_backward(
+            vocab_parallel_source_probs, vocab_parallel_target_topk_probs, vocab_parallel_target_topk_indices
+        )
+        # if get_data_parallel_rank() == 0 and get_tensor_model_parallel_rank() == 1:
+        #     import ipdb; ipdb.set_trace()
+        # torch.distributed.barrier()
+        return per_token_kl_loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        vocab_parallel_source_probs, vocab_parallel_target_topk_probs, vocab_parallel_target_topk_indices = (
+            ctx.saved_tensors
+        )
+        # source_probs, target_probs = ctx.saved_tensors
+        # KL 散度对 vocab_parallel_logits 的梯度为: (student_softmax_logits - valid_target_logits)
+        grad_input = vocab_parallel_source_probs  # shape: [seq_len, batch_size, vocab_parition_size]
+
+        topk = vocab_parallel_target_topk_indices.size(-1)
+        grad_input_2d = grad_input.view(-1, grad_input.size(-1))
+        arange_1d = torch.arange(start=0, end=grad_input_2d.size(0), device=grad_input_2d.device)  # (b*s, )
+        grad_input_2d[arange_1d.unsqueeze(-1), vocab_parallel_target_topk_indices.view(-1, topk)] -= (
+            vocab_parallel_target_topk_probs.view(-1, topk)
+        )
+
+        grad_input.mul_(grad_output.unsqueeze(dim=-1))
+
+        return grad_input, None, None  # 返回给第一个输入 vocab_parallel_logits 的梯度
+
+
+def vocab_parallel_kl_divergence(vocab_parallel_logits, target_topk_logps, target_topk_indices):
+    """
+    Performs cross entropy loss when logits are split across tensor parallel ranks.
+
+    Args:
+        vocab_parallel_logits: logits split across tensor parallel ranks
+                               dimension is [sequence_length, batch_size, vocab_size_per_partition]
+        target_topk_logits: logits split across tensor parallel ranks
+                                       dimension is [sequence_length, batch_size, top_k]
+
+    Returns:
+        loss: scalar tensor
+    """
+    return _VocabParallelKLDivergence.apply(vocab_parallel_logits, target_topk_logps, target_topk_indices)

--- a/gkd_ascend/megatron_utils.py
+++ b/gkd_ascend/megatron_utils.py
@@ -1,0 +1,200 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+# Copyright 2025 Individual Contributor: Brilliant Hanabi, furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from megatron.core import parallel_state as mpu
+
+import verl.utils.megatron.tensor_parallel as tp_utils
+from verl.utils.device import get_device_id
+from verl.utils.megatron_utils import default_tp_concat_fn, unwrap_model
+from verl.utils.model import normalize_model_name
+
+
+def per_tensor_generator(
+    actor_module,
+    model_config,
+    weight_converter,
+    transformer_config,
+    layer_name_mapping,
+    convert_qkv_gate_up_by_simple_split=True,
+):
+    tp_rank = mpu.get_tensor_model_parallel_rank()
+    pp_rank = mpu.get_pipeline_model_parallel_rank()
+    ep_rank = mpu.get_expert_model_parallel_rank()
+    etp_rank = mpu.get_expert_tensor_parallel_rank()
+    ep_size = mpu.get_expert_model_parallel_world_size()
+    etp_size = mpu.get_expert_tensor_parallel_world_size()
+    ep_group = mpu.get_expert_model_parallel_group()
+    etp_group = mpu.get_expert_tensor_parallel_group()
+    vpp_size = len(actor_module)
+    tp_group = mpu.get_tensor_model_parallel_group()
+    tp_size = torch.distributed.get_world_size(group=tp_group)
+
+    def tensor_generator():
+        for scan_vpp_idx in range(vpp_size):
+            existing_keys = set()
+            model = unwrap_model(actor_module[scan_vpp_idx])
+            for name, param in model.named_parameters():
+                existing_keys.add(name)
+                yield name, param
+            # note
+            # there is a bug in megatron GPTModel
+            # decoder.layers[n].mlp.router.expert_bias" in GPTModel is not registered in named_parameter, but in
+            # state_dict(). for now we patch it by adding those keys to extra_keys.
+            extra_keys = [x for x in model.state_dict().keys() if "_extra_state" not in x and x not in existing_keys]
+            for name in extra_keys:
+                yield name, model.state_dict()[name].to(get_device_id())
+
+    def get_tensor_spec(tensor):
+        shape = tensor.shape
+        dtype = tensor.dtype
+        tensor_parallel = getattr(tensor, "tensor_model_parallel", None)
+        partition_dim = getattr(tensor, "partition_dim", None)
+        tensor_spec = (shape, dtype, tensor_parallel, partition_dim)
+        return tensor_spec
+
+    def make_tensor(tensor_spec):
+        tensor = torch.empty(size=tensor_spec[0], dtype=tensor_spec[1], device=get_device_id())
+        if tensor_spec[2] is not None:
+            tensor.tensor_model_parallel = tensor_spec[2]
+        if tensor_spec[3] is not None:
+            tensor.partition_dim = tensor_spec[3]
+        return tensor
+
+    # we need first make all rank get full model information
+    meta_info = []
+    for scan_vpp_idx in range(vpp_size):
+        existing_keys = set()
+        model = unwrap_model(actor_module[scan_vpp_idx])
+        for idx, (name, param) in enumerate(model.named_parameters()):
+            existing_keys.add(name)
+            meta_info.append((pp_rank, scan_vpp_idx, idx, name, get_tensor_spec(param)))
+        extra_keys = [
+            (x, y) for x, y in model.state_dict().items() if "_extra_state" not in x and x not in existing_keys
+        ]
+        for name, param in extra_keys:
+            meta_info.append((pp_rank, scan_vpp_idx, idx, name, get_tensor_spec(param)))
+
+    obj_spec_output = [None] * mpu.get_pipeline_model_parallel_world_size()
+    torch.distributed.all_gather_object(
+        object_list=obj_spec_output, obj=meta_info, group=mpu.get_pipeline_model_parallel_group()
+    )
+    layer_list_meta = [item for sublist in obj_spec_output for item in sublist]
+
+    gen_func = tensor_generator()
+
+    # lazy load tensor for full model
+    for cur_pp_rank, scan_vpp_idx, idx, name, tensor_spec in layer_list_meta:
+        # fp.write(f"DEBUG: ({cur_pp_rank}, {scan_vpp_idx}, {name})\n")
+        if model_config.tie_word_embeddings and ("output_layers" in name):
+            import warnings
+
+            warnings.warn(
+                "Current model sharing word and embedding weights, skip output layer conversion", stacklevel=2
+            )
+            continue
+
+        cur_name = normalize_model_name(name, cur_pp_rank, scan_vpp_idx, transformer_config)
+
+        if cur_pp_rank == pp_rank:
+            _, cur_tensor = next(gen_func)
+
+        else:
+            cur_tensor = None
+
+        if pp_rank == 0:
+            if cur_tensor is None:
+                cur_tensor = make_tensor(tensor_spec)
+                torch.distributed.recv(cur_tensor, group=mpu.get_pipeline_model_parallel_group(), group_src=cur_pp_rank)
+        else:
+            if cur_tensor is None:
+                cur_tensor = make_tensor(tensor_spec)
+            else:
+                torch.distributed.send(cur_tensor, group=mpu.get_pipeline_model_parallel_group(), group_dst=0)
+
+        # (xya): this is a hack to fix the name of the parameters
+        while cur_name.startswith("module."):
+            cur_name = cur_name[len("module.") :]
+
+        def gather(tensor, gather_list, group, group_dst, group_rank):
+            if group_rank == group_dst:
+                torch.distributed.gather(tensor, gather_list, group=group, group_dst=group_dst)
+            else:
+                torch.distributed.gather(tensor, None, group=group, group_dst=group_dst)
+
+        # EP
+        if ".mlp.experts.linear_fc" in cur_name and ep_size > 1:
+            num_experts = weight_converter.mcore_config.num_moe_experts
+            num_experts_per_rank = num_experts // ep_size
+            infer_params = [torch.empty_like(cur_tensor) for _ in range(ep_size)]
+            gather(cur_tensor, infer_params, group=ep_group, group_dst=0, group_rank=ep_rank)
+
+            name_prefix, local_expert_id = cur_name.split(".weight")
+            local_expert_id = int(local_expert_id)
+            global_expert_ids = [num_experts_per_rank * _ep_rank + local_expert_id for _ep_rank in range(ep_size)]
+            global_expert_names = [f"{name_prefix}.weight{expert_id}" for expert_id in global_expert_ids]
+
+            for name, param in zip(global_expert_names, infer_params, strict=True):
+                if etp_size > 1:
+                    # gather etp
+                    etp_params = [torch.empty_like(param) for _ in range(etp_size)]
+                    gather(param, etp_params, group=etp_group, group_dst=0, group_rank=etp_rank)
+                    params = etp_params
+                else:
+                    params = [param]
+
+                merge_params = default_tp_concat_fn(
+                    layer_name_mapping,
+                    name,
+                    cur_tensor,
+                    params,
+                    model_config,
+                    weight_converter.hf_config,
+                    convert_qkv_gate_up_by_simple_split,
+                )
+                if not isinstance(merge_params, list):
+                    merge_params = [merge_params]
+                converted_names, converted_params = weight_converter.convert_param(name, merge_params)
+
+                yield from zip(converted_names, [param.detach() for param in converted_params], strict=True)
+
+            continue
+        # tp all gather
+        if tp_utils.is_tensor_parallel_param(cur_tensor):
+            # allocate a new tensor with proper size
+            if tp_size <= 1:
+                infer_params = [cur_tensor]
+            else:
+                infer_params = [torch.empty_like(cur_tensor) for _ in range(tp_size)]
+                gather(cur_tensor, infer_params, tp_group, group_dst=0, group_rank=tp_rank)
+            infer_params = default_tp_concat_fn(
+                layer_name_mapping,
+                cur_name,
+                cur_tensor,
+                infer_params,
+                model_config,
+                weight_converter.hf_config,
+                convert_qkv_gate_up_by_simple_split,
+            )
+        else:
+            infer_params = cur_tensor
+
+        if not isinstance(infer_params, list):
+            infer_params = [infer_params]
+        converted_names, converted_params = weight_converter.convert_param(cur_name, infer_params)
+
+        yield from zip(converted_names, [param.detach() for param in converted_params], strict=True)

--- a/gkd_ascend/megatron_workers.py
+++ b/gkd_ascend/megatron_workers.py
@@ -1,0 +1,663 @@
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import time
+
+from typing import Iterable
+import numpy as np
+import torch
+from megatron.core import parallel_state as mpu
+from megatron.core.pipeline_parallel import get_forward_backward_func
+from omegaconf import DictConfig, OmegaConf
+from ray.util.collective import collective
+
+from megatron_kl_loss import vocab_parallel_kl_divergence
+from distributed_util import vllm_stateless_init_process_group
+from verl import DataProto
+from verl.single_controller.base.decorator import (
+    Dispatch,
+    make_nd_compute_dataproto_dispatch_fn,
+    register,
+)
+from verl.utils.checkpoint.megatron_checkpoint_manager import MegatronCheckpointManager
+from verl.utils.device import get_device_id, get_device_name, get_torch_device, is_npu_available
+from verl.utils.flops_counter import FlopsCounter
+from verl.utils.megatron.pipeline_parallel import make_batch_generator
+from verl.utils.megatron_utils import load_megatron_model_to_gpu, offload_megatron_model_to_cpu
+from verl.utils.profiler import log_gpu_memory_usage
+from verl.utils.py_functional import append_to_dict
+from verl.utils.seqlen_balancing import rearrange_micro_batches
+from verl.workers.megatron_workers import AsyncActorRolloutRefWorker
+from verl.workers.actor.megatron_actor import MegatronPPOActor
+from verl.utils.ray_utils import get_event_loop
+from verl.utils.torch_functional import broadcast_dict_tensor
+from verl.utils.megatron.router_replay_utils import (
+    RouterReplayHelper,
+    reorder_and_merge_vpp_layers,
+)
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+device_name = get_device_name()
+
+
+def _ensure_required_actor_rollout_fields(config: DictConfig) -> None:
+    """Pad GKD configs with dummy fields that the up-to-date verl
+    `ActorRolloutRefWorker` expects during ``__init__`` (e.g. PPO batch sizes,
+    rollout sample count and router-replay options).
+
+    GKD uses pure on-policy distillation and therefore intentionally omits these
+    fields, but the parent class still references them while normalising the
+    config. We inject safe defaults instead of failing fast.
+    """
+    is_struct = OmegaConf.is_struct(config) or False
+    OmegaConf.set_struct(config, False)
+    try:
+        if OmegaConf.select(config, "actor") is not None:
+            actor_cfg = config.actor
+            if OmegaConf.select(actor_cfg, "ppo_mini_batch_size") is None:
+                actor_cfg.ppo_mini_batch_size = 1
+            if OmegaConf.select(actor_cfg, "ppo_micro_batch_size") is None:
+                # The parent worker only normalises this field when it is set,
+                # so leaving it as None keeps GKD's `micro_batch_size` flow.
+                pass
+            if OmegaConf.select(actor_cfg, "ppo_epochs") is None:
+                actor_cfg.ppo_epochs = 1
+            if OmegaConf.select(actor_cfg, "router_replay") is None:
+                actor_cfg.router_replay = OmegaConf.create({"mode": "disabled"})
+        if OmegaConf.select(config, "rollout") is not None:
+            rollout_cfg = config.rollout
+            if OmegaConf.select(rollout_cfg, "n") is None:
+                rollout_cfg.n = 1
+            if OmegaConf.select(rollout_cfg, "log_prob_micro_batch_size") is None:
+                # Same as above; only normalised when set.
+                pass
+    finally:
+        OmegaConf.set_struct(config, is_struct)
+
+
+class TensorBuffer:
+    def __init__(self, memory_alloc, dtype):
+        device = get_device_id()
+        dtype_size = torch.tensor([], dtype=dtype).element_size()
+        self.capacity = memory_alloc // dtype_size
+        self.tensor = torch.empty(self.capacity, dtype=dtype, device=device)
+        self.keys = []
+        self.shapes = []
+
+    @property
+    def size(self):
+        return sum(shape.numel() for shape in self.shapes)
+
+    def clear(self):
+        self.keys.clear()
+        self.shapes.clear()
+
+    def append(self, key, shape, weight=None):
+        if weight is not None:
+            self.tensor[self.size: self.size + shape.numel()] = weight.view(-1)
+        self.keys.append(key)
+        self.shapes.append(shape)
+
+    def to_tensors(self):
+        tensors = []
+        start = 0
+        for key_, shape_ in zip(self.keys, self.shapes, strict=False):
+            tensors.append((key_, self.tensor[start: start + shape_.numel()].view(shape_)))
+            start += shape_.numel()
+        return tensors
+
+
+def record_time(func):
+    def wrapper(*args, **kwargs):
+        tik = time.time()
+        func(*args, **kwargs)
+        tok = time.time()
+        return tok - tik
+
+    return wrapper
+
+
+class OnPolicyDistillActor(MegatronPPOActor):
+    """
+    Responsible purely for the training step (forward-backward + optimizer).
+    """
+
+    def make_minibatch_iterator(self, data: DataProto) -> Iterable[DataProto]:
+        """Make minibatch iterator for updating the actor
+
+        Args:
+            data (DataProto): a DataProto containing keys
+
+                ``input_ids``: tensor of shape [batch_size, sequence_length]. torch.int64, where
+                ``sequence_length = prompt_length + response_length``
+
+                ``attention_mask``: tensor of shape [batch_size, sequence_length]. torch.int64
+
+                ``position_ids``: tensor of shape [batch_size, sequence_length]. torch.int64
+
+                ``responses``: tensor of shape [batch_size, response_length]. torch.int64. Note that
+                responses = input_ids[:, -response_length:]
+
+                ``old_log_probs``: tensor of shape [batch_size, response_length]. torch.float32. The log probability
+                of responses.
+
+                ``advantages``: tensor of shape [batch_size, response_length]. torch.float32. The advantages of
+                responses.
+                See PPO paper for details. https://arxiv.org/abs/1707.06347
+
+        Returns:
+
+        """
+        select_keys = ["responses", "input_ids", "attention_mask", "position_ids"]
+        non_tensor_keys = ["teacher_topk_logps", "teacher_topk_indices"]
+
+        self.has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
+        # router replay
+        if self.enable_routing_replay:
+            select_keys.append("routed_experts")
+        if self.has_multi_modal_inputs:
+            non_tensor_keys.append("multi_modal_inputs")
+
+        data = data.select(batch_keys=select_keys, non_tensor_batch_keys=non_tensor_keys)
+
+        return data.make_iterator(
+            mini_batch_size=self.config.ppo_mini_batch_size,
+            epochs=self.config.ppo_epochs,
+            seed=self.config.data_loader_seed,
+            dataloader_kwargs={"shuffle": self.config.shuffle},
+        )
+
+    def forward_backward_batch(
+      self,
+      data: DataProto,
+      forward_only=False,
+      post_process_fn=None,
+      calculate_entropy=False,
+      use_dynamic_bsz=False,
+      micro_batch_size=None,
+      max_token_len=None,
+      mini_batch_size=None,
+    ):
+        """
+        We assume:
+        - The model takes input: (input_ids, attention_mask, position_ids). No rmpad for the input
+        - The communication shape is (total_nnz_pad_to_sp // tp_size, 1, hidden_size) if sequence parallel is enabled
+        """
+        # broadcast from last pp rank to all other pp ranks
+
+        data.to(get_device_id())
+        data.batch = data.batch.contiguous()
+        mini_batch = data
+        broadcast_dict_tensor(
+            mini_batch.batch,
+            src=mpu.get_pipeline_model_parallel_last_rank(),
+            group=mpu.get_pipeline_model_parallel_group(),
+        )
+        mini_batch.to("cpu")
+        # split into micro-batches
+        mini_batch.batch["attention_mask"] = mini_batch.batch["attention_mask"].to(bool)
+
+        if mpu.is_pipeline_last_stage():
+            for key, dtype in [("teacher_topk_logps", np.float32), ("teacher_topk_indices", np.int32)]:
+                if key in mini_batch.non_tensor_batch:
+                    arr = mini_batch.non_tensor_batch[key]
+                    if isinstance(arr, np.ndarray) and arr.dtype == object:
+                        mini_batch.non_tensor_batch[key] = np.stack(arr).astype(dtype)
+
+        indices = None
+        if use_dynamic_bsz:
+            assert max_token_len is not None, "max_token_len must be set when use_dynamic_bsz is True"
+            vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size()
+            if vpp_size is not None and vpp_size > 1:
+                microbatch_group_size_per_vp_stage = self.tf_config.microbatch_group_size_per_vp_stage
+                micro_batches, indices = rearrange_micro_batches(
+                    batch=mini_batch.batch,
+                    num_batches_divided_by=microbatch_group_size_per_vp_stage,
+                    max_token_len=max_token_len,
+                )
+                assert len(micro_batches) % self.tf_config.microbatch_group_size_per_vp_stage == 0, (
+                    f"micro_batches {len(micro_batches)} must be divisible by microbatch_group_size_per_vp_stage "
+                    f"{microbatch_group_size_per_vp_stage} for megatron backend"
+                )
+            else:
+                micro_batches, indices = rearrange_micro_batches(batch=mini_batch.batch, max_token_len=max_token_len)
+            # total_seqlen = max_token_len
+            if mpu.is_pipeline_last_stage():
+                teacher_topk_logps_tensor = torch.tensor(mini_batch.non_tensor_batch["teacher_topk_logps"])
+                teacher_topk_indices_tensor = torch.tensor(mini_batch.non_tensor_batch["teacher_topk_indices"])
+                teacher_topk_logps, teacher_topk_indices = [], []
+                for partition in indices:
+                    curr_logp_micro_batch, curr_idx_micro_batch = [], []
+                    for idx in partition:
+                        curr_logp_micro_batch.append(teacher_topk_logps_tensor[idx: idx + 1])
+                        curr_idx_micro_batch.append(teacher_topk_indices_tensor[idx: idx + 1])
+                    curr_logp_micro_batch = torch.cat(curr_logp_micro_batch)
+                    curr_idx_micro_batch = torch.cat(curr_idx_micro_batch)
+
+                    teacher_topk_logps.append(curr_logp_micro_batch)
+                    teacher_topk_indices.append(curr_idx_micro_batch)
+
+                for i, mb in enumerate(micro_batches):
+                    responses = mb["responses"]
+                    response_length = responses.size(1)
+                    calc_kl_mask = mb["attention_mask"].clone()
+                    calc_kl_mask[:, : (-response_length - 1)] = False
+                    mb["calc_kl_mask"] = calc_kl_mask
+                    mb["kl_losses"] = torch.zeros_like(calc_kl_mask, dtype=torch.float32)
+                    mb["teacher_topk_logps"] = teacher_topk_logps[i].pin_memory()
+                    mb["teacher_topk_indices"] = teacher_topk_indices[i].pin_memory()
+        else:
+            assert micro_batch_size is not None, (
+                "micro_batch_size is needed to be passed in when not using dynamic batch size"
+            )
+
+            micro_batches = mini_batch.batch.split(micro_batch_size)
+            # seq_len = micro_batches[0]["input_ids"].shape[1]
+            # total_seqlen = micro_batch_size * seq_len
+
+            if mpu.is_pipeline_last_stage():
+                teacher_topk_logps = np.array_split(mini_batch.non_tensor_batch["teacher_topk_logps"],
+                                                    len(micro_batches))
+                teacher_topk_indices = np.array_split(mini_batch.non_tensor_batch["teacher_topk_indices"],
+                                                      len(micro_batches))
+
+                for i, mb in enumerate(micro_batches):
+                    responses = mb["responses"]
+                    response_length = responses.size(1)
+                    calc_kl_mask = mb["attention_mask"].clone()
+                    calc_kl_mask[:, : (-response_length - 1)] = False
+                    mb["calc_kl_mask"] = calc_kl_mask
+                    mb["kl_losses"] = torch.zeros_like(calc_kl_mask, dtype=torch.float32)
+                    mb["teacher_topk_logps"] = torch.from_numpy(teacher_topk_logps[i]).pin_memory()
+                    mb["teacher_topk_indices"] = torch.from_numpy(teacher_topk_indices[i]).pin_memory()
+
+        # compute input shapes for pp stages
+        n_micro_batch = len(micro_batches)
+
+        forward_backward_func = get_forward_backward_func()
+
+        def loss_func(output):
+            # For memory efficiency
+            # We move calculation of entropy to compute_log_probs, forward_only == True
+            metrics = {}
+
+            ret_entropy = None
+            stats = {}
+            kl_losses = output["kl_losses"]
+            calc_kl_mask = output["calc_kl_mask"]
+            # inf_cnt = masked_kl_lossed.isinf().sum().item()
+            # nan_cnt = masked_kl_lossed.isnan().sum().item()
+            # total_cnt = masked_kl_lossed.nelement()
+            # print(f"rank: {rank}, kl_loss inf_cnt/nan_cnt/total_cnt: {inf_cnt} / {nan_cnt} /{total_cnt}")
+            masked_kl_lossed = kl_losses[calc_kl_mask]
+            mean_kl_loss = masked_kl_lossed.mean()
+            stats.update({"actor/kl_loss": mean_kl_loss.detach().item()})
+
+            append_to_dict(metrics, stats)
+            return mean_kl_loss, [metrics, ret_entropy]
+
+        def forward_step(batch_iter, model):
+            batch = next(batch_iter)
+            batch = batch.to(get_device_id())
+            batch = batch.contiguous()
+
+            input_ids = batch["input_ids"]
+            attention_mask = batch["attention_mask"]
+            position_ids = batch["position_ids"]
+
+            def logits_processor(logits, teacher_topk_logps, teacher_topk_indices, calc_kl_mask, kl_losses):
+                assert logits.shape[:2] == calc_kl_mask.shape[:2]
+                assert logits.shape[:2] == teacher_topk_indices.shape[:2]
+                assert logits.shape[:2] == teacher_topk_logps.shape[:2]
+
+                masked_logits = logits[calc_kl_mask]
+                masked_teacher_topk_logps = teacher_topk_logps[calc_kl_mask]
+                masked_teacher_topk_indices = teacher_topk_indices[calc_kl_mask]
+
+                kl_losses[calc_kl_mask] = vocab_parallel_kl_divergence(
+                    masked_logits, masked_teacher_topk_logps, masked_teacher_topk_indices
+                )
+                return {"kl_losses": kl_losses, "calc_kl_mask": calc_kl_mask}
+
+            if mpu.is_pipeline_last_stage():
+                device = get_device_id()
+                teacher_topk_logps = batch["teacher_topk_logps"].to(device, non_blocking=True)
+                teacher_topk_indices = batch["teacher_topk_indices"].to(device, non_blocking=True)
+                logits_processor_args = {
+                    "calc_kl_mask": batch["calc_kl_mask"],
+                    "kl_losses": batch["kl_losses"],
+                    "teacher_topk_logps": teacher_topk_logps,
+                    "teacher_topk_indices": teacher_topk_indices,
+                }
+            else:
+                logits_processor_args = None
+
+            multi_modal_inputs = {}
+            if "multi_modal_inputs" in batch:
+                from verl.utils.model import extract_multi_modal_inputs
+
+                indices = batch.get("multi_modal_inputs_idx", None)
+                multi_modal_inputs = extract_multi_modal_inputs(batch["multi_modal_inputs"], indices)
+
+            from verl.models.mcore import get_mcore_forward_fn
+
+            forward_fn = get_mcore_forward_fn(self.hf_config)
+
+            output = forward_fn(
+                model,
+                input_ids,
+                attention_mask,
+                position_ids,
+                multi_modal_inputs,
+                logits_processor=logits_processor,
+                logits_processor_args=logits_processor_args,
+            )
+
+            return output, loss_func
+
+        # batch should be a list of batches inside micro-batches
+        batch_generator = make_batch_generator(micro_batches, vpp_size=len(self.actor_module))
+
+        # TODO: we may use the new schedule instead
+        # for flash-attn: (seq_len, batch_size, hidden_size) = (mbs*seq_len, 1, hidden_size)
+        losses_reduced = forward_backward_func(
+            forward_step_func=forward_step,
+            data_iterator=batch_generator,
+            model=self.actor_module,
+            num_microbatches=n_micro_batch,
+            seq_length=-1,  # no use when variable_seq_lengths was set
+            micro_batch_size=-1,  # no use when variable_seq_lengths was set
+            forward_only=False,
+        )
+
+        # loss_reduces contains the stats returned from loss_func
+
+        losses_reduced = {"output": losses_reduced}
+        if use_dynamic_bsz:
+            losses_reduced["indices"] = indices
+        if RouterReplayHelper.is_r2_record_action(self.tf_config):
+            if self.tf_config.virtual_pipeline_model_parallel_size is not None:
+                # config = self.actor_module[0].module.module.config
+                vp_size = len(self.actor_module)
+                microbatch_group_size_per_vp_stage = self.tf_config.microbatch_group_size_per_vp_stage
+                bs = n_micro_batch
+                losses_reduced["mini_layer_topk_idx_tensor"] = reorder_and_merge_vpp_layers(
+                    self.mini_layer_topk_idx_list, bs, vp_size, microbatch_group_size_per_vp_stage
+                )
+            else:
+                losses_reduced["mini_layer_topk_idx_tensor"] = torch.cat(self.mini_layer_topk_idx_list, dim=0)
+            self.mini_layer_topk_idx_list = []
+
+        return losses_reduced
+
+
+class DetachSync(AsyncActorRolloutRefWorker):
+    def _get_actor_params(self):
+        pass
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
+    def create_weight_sync_group(self, master_address, master_port, rank_offset, world_size):
+        rank = torch.distributed.get_rank() + rank_offset
+        self._weight_sync_group = vllm_stateless_init_process_group(
+            master_address,
+            master_port,
+            rank,
+            world_size,
+            get_torch_device().current_device(),
+        )
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
+    def sync_rollout_weights(self):
+        assert (self._is_actor or self._is_rollout) and not self.config.hybrid_engine
+        assert hasattr(self, "_weights_info") and self._weights_info is not None
+
+        params_generator = self._get_actor_params_generator() if self._is_actor else None
+
+        if self._is_actor and self._is_offload_param:
+            load_megatron_model_to_gpu(self.actor_module)
+
+        rollout_name = self.config.rollout.name
+        if self._is_rollout:
+            if rollout_name == "vllm":
+                from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
+
+                inference_model = self.rollout.inference_engine.worker.model_runner.model
+                patch_vllm_moe_model_weight_loader(inference_model)
+            elif rollout_name == "sglang":
+                inference_model = self.rollout._engine
+            else:
+                raise NotImplementedError(f"Unknown rollout name: {rollout_name}")
+
+        loop = get_event_loop()
+        for key, shape, dtype in self._weights_info:
+            if self._is_actor:
+                weight_key, weight = next(params_generator)
+                assert key == weight_key
+                assert shape == weight.size()
+                assert dtype == weight.dtype
+
+            tensor = torch.empty(shape, dtype=dtype, device=get_torch_device().current_device())
+            if self._is_actor and torch.distributed.get_rank() == 0:
+                tensor.copy_(weight)
+
+            if device_name == "npu":
+                self._weight_sync_group.broadcast(tensor, src=0, stream=get_torch_device().current_stream())
+            else:
+                collective.broadcast(tensor, src_rank=0, group_name="actor_rollout")
+
+            if self._is_rollout:
+                if rollout_name == "vllm":
+                    inference_model.load_weights([(key, tensor)])
+                elif rollout_name == "sglang":
+                    # first_rank_in_node = self._tp_rank % tp_size_per_node == 0，
+                    # Only the first rank within each node (i.e., the local rank is 0) initializes the engine;
+                    # engines for other ranks are set to None.
+
+                    if inference_model is not None:
+                        loop.run_until_complete(self.update_weights(inference_model, [(key, tensor)]))
+
+        if self._is_actor and self._is_offload_param:
+            offload_megatron_model_to_cpu(self.actor_module)
+
+    async def update_weights(self, inference_engine, params):
+        from sglang.srt.weight_sync.utils import update_weights as sgl_update_weights
+
+        await sgl_update_weights(
+            engine=inference_engine,
+            params_batch=params,
+            device_mesh_key="infer_tp",
+            device_mesh=self.rollout_device_mesh,
+        )
+
+        if self.rollout_device_mesh["infer_tp"].get_local_rank() == 0:
+            await inference_engine.flush_cache()
+
+
+class MegatronOnPolicyDistillActorWorker(DetachSync):
+    """
+    Actor-only worker: owns the trainable Megatron model and optimizer, performs update_actor.
+    """
+
+    def __init__(self, config: DictConfig, role: str, **kwargs):
+        # Ensure we run as actor-only worker
+        _ensure_required_actor_rollout_fields(config)
+
+        super().__init__(config, role, **kwargs)
+        assert self._is_actor and not self._is_rollout, "Actor worker must be actor-only."
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def _get_actor_params_generator(self):
+        assert self._is_actor
+        if self.bridge is not None:
+            generator = self.bridge.export_weights(self.actor.actor_module)
+        else:
+            # from verl.utils.megatron_utils import per_tensor_generator
+            from megatron_utils import per_tensor_generator
+
+            from verl.models.mcore import get_mcore_weight_converter
+
+            layer_name_mapping = {
+                "qkv_layer_name": "self_attention.linear_qkv.",
+                "gate_proj_layer_name": "linear_fc1.",
+            }
+            weight_converter = get_mcore_weight_converter(self.actor_model_config, self.dtype)
+            generator = per_tensor_generator(
+                self.actor.actor_module,
+                self.actor_model_config,
+                weight_converter,
+                self.tf_config,
+                layer_name_mapping,
+            )
+        return generator
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        from verl.utils.torch_dtypes import PrecisionType
+
+        override_model_config = OmegaConf.to_container(self.config.model.get("override_config", OmegaConf.create()))
+        override_transformer_config = OmegaConf.to_container(
+            self.config.actor.megatron.get("override_transformer_config", OmegaConf.create()), resolve=True
+        )
+        # `override_ddp_config` was added in the up-to-date verl `_build_model_optimizer`
+        # signature. Resolve it from config (default to empty dict) for forward-compat.
+        override_ddp_config = OmegaConf.to_container(
+            OmegaConf.create(self.config.actor.megatron.get("override_ddp_config", {}))
+        )
+
+        self.param_dtype = torch.bfloat16
+        log_gpu_memory_usage("Before init actor model and optimizer", logger=logger)
+        self.dtype = PrecisionType.to_dtype(self.param_dtype)
+        # we need the model for actor and rollout
+        optim_config = self.config.actor.optim
+        (
+            self.actor_module,
+            self.actor_optimizer,
+            self.actor_optimizer_scheduler,
+            self.actor_model_config,
+            self.actor_optim_config,
+        ) = self._build_model_optimizer(
+            model_path=self.config.model.path,
+            optim_config=optim_config,
+            override_model_config=override_model_config,
+            override_transformer_config=override_transformer_config,
+            override_ddp_config=override_ddp_config,
+        )
+
+        self.actor = OnPolicyDistillActor(
+            config=self.config.actor,
+            model_config=self.actor_model_config,
+            hf_config=self.hf_config,
+            tf_config=self.tf_config,
+            actor_module=self.actor_module,
+            actor_optimizer=self.actor_optimizer,
+        )
+        log_gpu_memory_usage("After OnPolicyDistillActor init", logger=logger)
+
+        self.flops_counter = FlopsCounter(self.actor_model_config)
+        # NOTE: in the up-to-date verl `MegatronCheckpointManager`, additional
+        # optional kwargs (`provider`, `peft_cls`) were introduced. Pass them
+        # through if available so that GKD plays nicely with both old and new versions.
+        self.checkpoint_mananager = MegatronCheckpointManager(
+            config=self.config,
+            checkpoint_config=self.config.actor.checkpoint,
+            model_config=self.actor_model_config,
+            transformer_config=self.tf_config,
+            role="actor",
+            model=self.actor_module,
+            arch=self.architectures[0],
+            hf_config=self.hf_config,
+            param_dtype=self.param_dtype,
+            share_embeddings_and_output_weights=self.share_embeddings_and_output_weights,
+            processing_class=self.processor if self.processor is not None else self.tokenizer,
+            optimizer=self.actor_optimizer,
+            optimizer_scheduler=self.actor_optimizer_scheduler,
+            use_distributed_optimizer=self.config.actor.megatron.use_distributed_optimizer,
+            use_checkpoint_opt_param_scheduler=self.config.actor.optim.use_checkpoint_opt_param_scheduler,
+
+            bridge=self.bridge,
+            provider=self.provider,
+            use_dist_checkpointing=self.config.actor.megatron.use_dist_checkpointing,
+            peft_cls=self.peft_cls,
+        )
+        get_torch_device().empty_cache()
+        log_gpu_memory_usage("Actor init_model finished", logger=logger)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def get_actor_weights_info(self):
+        assert self._is_actor
+        if hasattr(self, "_weights_info"):
+            return self._weights_info
+        if self._is_offload_param:
+            load_megatron_model_to_gpu(self.actor_module)
+        params_generator = self._get_actor_params_generator()
+        ret = []
+        for key, tensor in params_generator:
+            ret.append((key, tensor.size(), tensor.dtype))
+
+        self._weights_info = ret
+        # Here, we only call this function at the beginning,
+        # and immediately afterwards we call sync_rollout_weights.
+        # So we no longer call offload in this.
+        return ret
+
+
+class MegatronOnPolicyDistillRolloutWorker(DetachSync):
+    """
+    Rollout-only worker: owns the inference engine (vLLM/SGlang, or Megatron forward) and generates sequences.
+    """
+
+    def __init__(self, config: DictConfig, role: str, **kwargs):
+        # The up-to-date verl ActorRolloutRefWorker.__init__ already handles all the
+        # heavy lifting (process group init, profiler, offload flags, ...). For a
+        # rollout-only worker the actor branches in the parent are skipped, so we
+        # can simply delegate the construction once mandatory fields are present.
+        _ensure_required_actor_rollout_fields(config)
+
+        from verl.utils.fs import copy_to_local
+        from verl.utils.model import get_generation_config
+
+        super().__init__(config, role, **kwargs)
+        assert self.role == "rollout"
+        assert self._is_rollout and not self._is_actor and not self._is_ref, (
+            "Rollout worker must be rollout-only."
+        )
+
+        # Cached locally because the parent class only sets `self.local_path`
+        # inside `_init_hf_config_and_tf_config`, which we still want to call
+        # when the rollout engine boots up. Pre-fetching the model files here
+        # is a no-op when `_init_hf_config_and_tf_config` runs later.
+        self.local_path = copy_to_local(self.config.model.path)
+        self.generation_config = get_generation_config(self.local_path)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        """
+        Build the actor module only for inference + rollout engine; no optimizer/updates.
+        """
+        from verl.utils.torch_dtypes import PrecisionType
+
+        self.param_dtype = torch.bfloat16
+        log_gpu_memory_usage("Before init rollout model", logger=logger)
+        self.dtype = PrecisionType.to_dtype(self.param_dtype)
+
+        self._build_rollout(trust_remote_code=self.config.model.get("trust_remote_code", False))
+        # In the up-to-date verl, `_build_rollout` exposes the device mesh via
+        # `self.rollout.device_mesh`. Older versions used `self.rollout_device_mesh`,
+        # so guard the access for backwards compatibility.
+        self.rollout_device_mesh = getattr(self.rollout, "device_mesh", None)
+        log_gpu_memory_usage("After rollout init", logger=logger)
+        get_torch_device().empty_cache()
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="rollout"), blocking=False)
+    def async_generate_sequences(self, *args, **kwargs):
+        return self.generate_sequences(*args, **kwargs)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def set_actor_weights_info(self, weights_info):
+        assert self._is_rollout
+        self._weights_info = weights_info

--- a/gkd_ascend/megatron_workers.py
+++ b/gkd_ascend/megatron_workers.py
@@ -5,17 +5,17 @@
 import logging
 import os
 import time
-
 from typing import Iterable
+
 import numpy as np
 import torch
+from distributed_util import vllm_stateless_init_process_group
 from megatron.core import parallel_state as mpu
 from megatron.core.pipeline_parallel import get_forward_backward_func
+from megatron_kl_loss import vocab_parallel_kl_divergence
 from omegaconf import DictConfig, OmegaConf
 from ray.util.collective import collective
 
-from megatron_kl_loss import vocab_parallel_kl_divergence
-from distributed_util import vllm_stateless_init_process_group
 from verl import DataProto
 from verl.single_controller.base.decorator import (
     Dispatch,
@@ -23,21 +23,21 @@ from verl.single_controller.base.decorator import (
     register,
 )
 from verl.utils.checkpoint.megatron_checkpoint_manager import MegatronCheckpointManager
-from verl.utils.device import get_device_id, get_device_name, get_torch_device, is_npu_available
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.megatron.pipeline_parallel import make_batch_generator
-from verl.utils.megatron_utils import load_megatron_model_to_gpu, offload_megatron_model_to_cpu
-from verl.utils.profiler import log_gpu_memory_usage
-from verl.utils.py_functional import append_to_dict
-from verl.utils.seqlen_balancing import rearrange_micro_batches
-from verl.workers.megatron_workers import AsyncActorRolloutRefWorker
-from verl.workers.actor.megatron_actor import MegatronPPOActor
-from verl.utils.ray_utils import get_event_loop
-from verl.utils.torch_functional import broadcast_dict_tensor
 from verl.utils.megatron.router_replay_utils import (
     RouterReplayHelper,
     reorder_and_merge_vpp_layers,
 )
+from verl.utils.megatron_utils import load_megatron_model_to_gpu, offload_megatron_model_to_cpu
+from verl.utils.profiler import log_gpu_memory_usage
+from verl.utils.py_functional import append_to_dict
+from verl.utils.ray_utils import get_event_loop
+from verl.utils.seqlen_balancing import rearrange_micro_batches
+from verl.utils.torch_functional import broadcast_dict_tensor
+from verl.workers.actor.megatron_actor import MegatronPPOActor
+from verl.workers.megatron_workers import AsyncActorRolloutRefWorker
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -99,7 +99,7 @@ class TensorBuffer:
 
     def append(self, key, shape, weight=None):
         if weight is not None:
-            self.tensor[self.size: self.size + shape.numel()] = weight.view(-1)
+            self.tensor[self.size : self.size + shape.numel()] = weight.view(-1)
         self.keys.append(key)
         self.shapes.append(shape)
 
@@ -107,7 +107,7 @@ class TensorBuffer:
         tensors = []
         start = 0
         for key_, shape_ in zip(self.keys, self.shapes, strict=False):
-            tensors.append((key_, self.tensor[start: start + shape_.numel()].view(shape_)))
+            tensors.append((key_, self.tensor[start : start + shape_.numel()].view(shape_)))
             start += shape_.numel()
         return tensors
 
@@ -173,15 +173,15 @@ class OnPolicyDistillActor(MegatronPPOActor):
         )
 
     def forward_backward_batch(
-      self,
-      data: DataProto,
-      forward_only=False,
-      post_process_fn=None,
-      calculate_entropy=False,
-      use_dynamic_bsz=False,
-      micro_batch_size=None,
-      max_token_len=None,
-      mini_batch_size=None,
+        self,
+        data: DataProto,
+        forward_only=False,
+        post_process_fn=None,
+        calculate_entropy=False,
+        use_dynamic_bsz=False,
+        micro_batch_size=None,
+        max_token_len=None,
+        mini_batch_size=None,
     ):
         """
         We assume:
@@ -234,8 +234,8 @@ class OnPolicyDistillActor(MegatronPPOActor):
                 for partition in indices:
                     curr_logp_micro_batch, curr_idx_micro_batch = [], []
                     for idx in partition:
-                        curr_logp_micro_batch.append(teacher_topk_logps_tensor[idx: idx + 1])
-                        curr_idx_micro_batch.append(teacher_topk_indices_tensor[idx: idx + 1])
+                        curr_logp_micro_batch.append(teacher_topk_logps_tensor[idx : idx + 1])
+                        curr_idx_micro_batch.append(teacher_topk_indices_tensor[idx : idx + 1])
                     curr_logp_micro_batch = torch.cat(curr_logp_micro_batch)
                     curr_idx_micro_batch = torch.cat(curr_idx_micro_batch)
 
@@ -261,10 +261,12 @@ class OnPolicyDistillActor(MegatronPPOActor):
             # total_seqlen = micro_batch_size * seq_len
 
             if mpu.is_pipeline_last_stage():
-                teacher_topk_logps = np.array_split(mini_batch.non_tensor_batch["teacher_topk_logps"],
-                                                    len(micro_batches))
-                teacher_topk_indices = np.array_split(mini_batch.non_tensor_batch["teacher_topk_indices"],
-                                                      len(micro_batches))
+                teacher_topk_logps = np.array_split(
+                    mini_batch.non_tensor_batch["teacher_topk_logps"], len(micro_batches)
+                )
+                teacher_topk_indices = np.array_split(
+                    mini_batch.non_tensor_batch["teacher_topk_indices"], len(micro_batches)
+                )
 
                 for i, mb in enumerate(micro_batches):
                     responses = mb["responses"]
@@ -578,7 +580,6 @@ class MegatronOnPolicyDistillActorWorker(DetachSync):
             optimizer_scheduler=self.actor_optimizer_scheduler,
             use_distributed_optimizer=self.config.actor.megatron.use_distributed_optimizer,
             use_checkpoint_opt_param_scheduler=self.config.actor.optim.use_checkpoint_opt_param_scheduler,
-
             bridge=self.bridge,
             provider=self.provider,
             use_dist_checkpointing=self.config.actor.megatron.use_dist_checkpointing,
@@ -623,9 +624,7 @@ class MegatronOnPolicyDistillRolloutWorker(DetachSync):
 
         super().__init__(config, role, **kwargs)
         assert self.role == "rollout"
-        assert self._is_rollout and not self._is_actor and not self._is_ref, (
-            "Rollout worker must be rollout-only."
-        )
+        assert self._is_rollout and not self._is_actor and not self._is_ref, "Rollout worker must be rollout-only."
 
         # Cached locally because the parent class only sets `self.local_path`
         # inside `_init_hf_config_and_tf_config`, which we still want to call

--- a/gkd_ascend/ray_trainer.py
+++ b/gkd_ascend/ray_trainer.py
@@ -371,7 +371,7 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
             result = await teacher_future
         yield *result, timing
 
-    def two_step_off_scheduler(self, continuous_iterator):
+    async def two_step_off_scheduler(self, continuous_iterator):
         """Two-step-off scheduler implementation for GKD training with optimized pipeline.
 
         This scheduler implements a double-buffered pipeline that overlaps:

--- a/gkd_ascend/ray_trainer.py
+++ b/gkd_ascend/ray_trainer.py
@@ -18,8 +18,8 @@ FSDP PPO Trainer with Ray-based single controller.
 This trainer supports model-agonistic model initialization with huggingface
 """
 
-import time
 import asyncio
+import time
 import uuid
 
 import numpy as np
@@ -27,6 +27,8 @@ import ray
 import torch
 from omegaconf import OmegaConf
 from ray.util.collective import collective
+from teacher import TeacherClient
+from teacher_utils import get_teacher_knowledge
 from torch.utils.data import Dataset, Sampler
 from tqdm import tqdm
 
@@ -38,19 +40,13 @@ from verl.trainer.ppo.metric_utils import (
     compute_throughout_metrics,
     compute_timing_metrics,
 )
-from verl.trainer.ppo.ray_trainer import (
-    RayPPOTrainer,
-    ResourcePoolManager
-)
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer, ResourcePoolManager
 from verl.trainer.ppo.utils import Role, WorkerType
 from verl.utils.debug import marked_timer
 from verl.utils.metric import (
     reduce_metrics,
 )
 from verl.utils.tracking import ValidationGenerationsLogger
-
-from teacher import TeacherClient
-from teacher_utils import get_teacher_knowledge
 
 
 class OnPolicyDistillTrainer(RayPPOTrainer):
@@ -64,18 +60,18 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
     # TODO: support each role have individual ray_worker_group_cls,
     # i.e., support different backend of different role
     def __init__(
-      self,
-      config,
-      tokenizer,
-      role_worker_mapping: dict[Role, WorkerType],
-      resource_pool_manager: ResourcePoolManager,
-      ray_worker_group_cls: RayWorkerGroup = RayWorkerGroup,
-      processor=None,
-      train_dataset: Dataset | None = None,
-      val_dataset: Dataset | None = None,
-      collate_fn=None,
-      train_sampler: Sampler | None = None,
-      device_name="cuda",
+        self,
+        config,
+        tokenizer,
+        role_worker_mapping: dict[Role, WorkerType],
+        resource_pool_manager: ResourcePoolManager,
+        ray_worker_group_cls: RayWorkerGroup = RayWorkerGroup,
+        processor=None,
+        train_dataset: Dataset | None = None,
+        val_dataset: Dataset | None = None,
+        collate_fn=None,
+        train_sampler: Sampler | None = None,
+        device_name="cuda",
     ):
         """
         Initialize distributed PPO trainer with Ray backend.
@@ -167,8 +163,8 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
             # Only require nsight worker options when tool is nsys
             if OmegaConf.select(self.config.global_profiler, "tool") == "nsys":
                 assert (
-                  OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
-                  is not None
+                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                    is not None
                 ), "worker_nsight_options must be set when using nsys with profile_steps"
                 wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
                     OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
@@ -267,9 +263,7 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
         batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
 
         # add uid to batch
-        batch.non_tensor_batch["uid"] = np.array(
-            [str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object
-        )
+        batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
 
         gen_batch = self._get_gen_batch(batch)
         gen_batch.meta_info["global_steps"] = self.global_steps
@@ -297,8 +291,9 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
         """
         epoch, batch, gen_batch_output = await gen_res
         gen_batch_output.meta_info["response_length"] = self.config.data.max_response_length
-        teacher_batch_output = get_teacher_knowledge(gen_batch_output, self.teacher_client, self.n_server_workers,
-                                                     is_async=False)
+        teacher_batch_output = get_teacher_knowledge(
+            gen_batch_output, self.teacher_client, self.n_server_workers, is_async=False
+        )
         return epoch, batch, gen_batch_output, teacher_batch_output
 
     async def one_step_off_scheduler(self, continuous_iterator):
@@ -339,7 +334,8 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
                 # we don't need to sync weights here because we have not trained the actor yet
                 # start second async rollout
                 rollout_future = asyncio.create_task(
-                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False))
+                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False)
+                )
                 # wait for generating teacher knowledge finish
                 # and get previous result including rollout and teacher knowledge
                 with marked_timer("wait_prev_teacher", timing):
@@ -413,7 +409,8 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
             elif i == 1:
                 teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
                 rollout_future = asyncio.create_task(
-                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False))
+                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False)
+                )
                 continue
             elif i == 2:
                 with marked_timer("wait_prev_prev_teacher", timing):
@@ -422,7 +419,8 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
                     teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
 
                 rollout_future = asyncio.create_task(
-                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False))
+                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False)
+                )
                 yield *result, timing
                 timing = {}
             else:
@@ -509,7 +507,7 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
                 if teacher_batch_output is None:
                     # save model
                     if self.config.trainer.save_freq > 0 and (
-                      is_last_step or self.global_steps % self.config.trainer.save_freq == 0
+                        is_last_step or self.global_steps % self.config.trainer.save_freq == 0
                     ):
                         self._save_checkpoint()
                     print("Error in getting teacher knowledge. Skip this batch.")
@@ -573,7 +571,7 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
 
                 # save model
                 if self.config.trainer.save_freq > 0 and (
-                  is_last_step or self.global_steps % self.config.trainer.save_freq == 0
+                    is_last_step or self.global_steps % self.config.trainer.save_freq == 0
                 ):
                     with marked_timer("save_checkpoint", timing_raw, color="green"):
                         self._save_checkpoint()

--- a/gkd_ascend/ray_trainer.py
+++ b/gkd_ascend/ray_trainer.py
@@ -1,0 +1,606 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+FSDP PPO Trainer with Ray-based single controller.
+This trainer supports model-agonistic model initialization with huggingface
+"""
+
+import time
+import asyncio
+import uuid
+
+import numpy as np
+import ray
+import torch
+from omegaconf import OmegaConf
+from ray.util.collective import collective
+from torch.utils.data import Dataset, Sampler
+from tqdm import tqdm
+
+from verl import DataProto
+from verl.experimental.dataset.sampler import AbstractCurriculumSampler
+from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup
+from verl.single_controller.ray.base import create_colocated_worker_cls
+from verl.trainer.ppo.metric_utils import (
+    compute_throughout_metrics,
+    compute_timing_metrics,
+)
+from verl.trainer.ppo.ray_trainer import (
+    RayPPOTrainer,
+    ResourcePoolManager
+)
+from verl.trainer.ppo.utils import Role, WorkerType
+from verl.utils.debug import marked_timer
+from verl.utils.metric import (
+    reduce_metrics,
+)
+from verl.utils.tracking import ValidationGenerationsLogger
+
+from teacher import TeacherClient
+from teacher_utils import get_teacher_knowledge
+
+
+class OnPolicyDistillTrainer(RayPPOTrainer):
+    """Distributed PPO trainer using Ray for scalable reinforcement learning.
+
+    This trainer orchestrates distributed PPO training across multiple nodes and GPUs,
+    managing actor rollouts, critic training, and reward computation with Ray backend.
+    Supports various model architectures including FSDP, Megatron, and vLLM integration.
+    """
+
+    # TODO: support each role have individual ray_worker_group_cls,
+    # i.e., support different backend of different role
+    def __init__(
+      self,
+      config,
+      tokenizer,
+      role_worker_mapping: dict[Role, WorkerType],
+      resource_pool_manager: ResourcePoolManager,
+      ray_worker_group_cls: RayWorkerGroup = RayWorkerGroup,
+      processor=None,
+      train_dataset: Dataset | None = None,
+      val_dataset: Dataset | None = None,
+      collate_fn=None,
+      train_sampler: Sampler | None = None,
+      device_name="cuda",
+    ):
+        """
+        Initialize distributed PPO trainer with Ray backend.
+        Note that this trainer runs on the driver process on a single CPU/GPU node.
+
+        Args:
+            config: Configuration object containing training parameters.
+            tokenizer: Tokenizer used for encoding and decoding text.
+            role_worker_mapping (dict[Role, WorkerType]): Mapping from roles to worker classes.
+            resource_pool_manager (ResourcePoolManager): Manager for Ray resource pools.
+            ray_worker_group_cls (RayWorkerGroup, optional): Class for Ray worker groups. Defaults to RayWorkerGroup.
+            processor: Optional data processor, used for multimodal data
+            reward_fn: Function for computing rewards during training.
+            val_reward_fn: Function for computing rewards during validation.
+            train_dataset (Optional[Dataset], optional): Training dataset. Defaults to None.
+            val_dataset (Optional[Dataset], optional): Validation dataset. Defaults to None.
+            collate_fn: Function to collate data samples into batches.
+            train_sampler (Optional[Sampler], optional): Sampler for the training dataset. Defaults to None.
+            device_name (str, optional): Device name for training (e.g., "cuda", "cpu"). Defaults to "cuda".
+        """
+
+        # Store the tokenizer for text processing
+        self.tokenizer = tokenizer
+        self.processor = processor
+        self.config = config
+
+        self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
+        assert not self.hybrid_engine
+
+        self.role_worker_mapping = role_worker_mapping
+        self.resource_pool_manager = resource_pool_manager
+        self.ray_worker_group_cls = ray_worker_group_cls
+        self.device_name = device_name
+        # The up-to-date verl ValidationGenerationsLogger is a dataclass that
+        # accepts `project_name`/`experiment_name`; older versions ignored them.
+        self.validation_generations_logger = ValidationGenerationsLogger(
+            project_name=config.trainer.project_name,
+            experiment_name=config.trainer.experiment_name,
+        )
+        self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
+        self.teacher_config = self.config.actor_rollout_ref.teacher
+        self.n_server_workers = self.teacher_config.n_server_workers
+        self.teacher_client = TeacherClient(
+            self.teacher_config.server_ip, self.teacher_config.server_port, n_server_workers=self.n_server_workers
+        )
+
+    def init_workers(self):
+        """Initialize distributed training workers using Ray backend.
+
+        Creates:
+        1. Ray resource pools from configuration
+        2. Worker groups for each role (actor, critic, etc.)
+        """
+
+        self._init_resource_pools()
+        self._create_actor_rollout_classes()
+        self._init_worker_groups()
+        self._init_models()
+        self._init_async_rollout_manager()
+
+    def _init_resource_pools(self):
+        self.resource_pool_manager.create_resource_pool()
+
+        self.resource_pool_to_cls = {pool: {} for pool in self.resource_pool_manager.resource_pool_dict.values()}
+
+    def _create_actor_rollout_classes(self):
+        for role in [Role.Actor, Role.Rollout]:
+            resource_pool = self.resource_pool_manager.get_resource_pool(role)
+            role_cls = RayClassWithInitArgs(
+                cls=self.role_worker_mapping[role],
+                config=self.config.actor_rollout_ref,
+                role=str(role),
+            )
+            self.resource_pool_to_cls[resource_pool][str(role)] = role_cls
+
+    def _init_worker_groups(self):
+        # initialize WorkerGroup
+        # NOTE: if you want to use a different resource pool for each role, which can support different parallel size,
+        # you should not use `create_colocated_worker_cls`.
+        # Instead, directly pass different resource pool to different worker groups.
+        # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
+        all_wg = {}
+        wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
+        if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
+            wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
+        if OmegaConf.select(self.config.global_profiler, "steps") is not None:
+            wg_kwargs["profile_steps"] = OmegaConf.select(self.config.global_profiler, "steps")
+            # Only require nsight worker options when tool is nsys
+            if OmegaConf.select(self.config.global_profiler, "tool") == "nsys":
+                assert (
+                  OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                  is not None
+                ), "worker_nsight_options must be set when using nsys with profile_steps"
+                wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
+                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                )
+
+        for resource_pool, class_dict in self.resource_pool_to_cls.items():
+            worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
+            wg_dict = self.ray_worker_group_cls(
+                resource_pool=resource_pool,
+                ray_cls_with_init=worker_dict_cls,
+                device_name=self.device_name,
+                **wg_kwargs,
+            )
+            spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
+            all_wg.update(spawn_wg)
+            time.sleep(20)  # avoid port conflict
+
+        self.rollout_wg = all_wg["rollout"]
+        self.actor_wg = all_wg["actor"]
+
+    def _init_models(self):
+        # Initialize both groups
+        self.actor_wg.init_model()
+        self.rollout_wg.init_model()
+        self.actor_rollout_wg = self.actor_wg  # to be compatible with the functions that not be modified
+        weights_info = self.actor_wg.get_actor_weights_info()[0]
+        self.rollout_wg.set_actor_weights_info(weights_info)
+        self._create_weight_sync_group()
+
+    def _create_weight_sync_group(self):
+        from verl.utils.device import get_nccl_backend
+
+        actor_rollout_workers = self.actor_wg.workers + self.rollout_wg.workers
+        n_workers = len(actor_rollout_workers)
+
+        if self.device_name == "npu":
+            master_address = ray.get(self.actor_wg.workers[0]._get_node_ip.remote())
+            master_port = ray.get(self.actor_wg.workers[0]._get_free_port.remote())
+            self.actor_wg.create_weight_sync_group(
+                master_address,
+                master_port,
+                0,
+                n_workers,
+            )
+            ray.get(
+                self.rollout_wg.create_weight_sync_group(
+                    master_address,
+                    master_port,
+                    len(self.actor_wg.workers),
+                    n_workers,
+                )
+            )
+        else:
+            # Create Ray collective group for fallback communication
+            collective.create_collective_group(
+                actor_rollout_workers,
+                n_workers,
+                list(range(0, n_workers)),
+                backend=get_nccl_backend(),
+                group_name="actor_rollout",
+            )
+
+    def _init_async_rollout_manager(self):
+        # create async rollout manager and request scheduler
+        assert self.config.actor_rollout_ref.rollout.mode == "async"
+        from agent_loop import GKDAgentLoopManager
+
+        self.async_rollout_mode = True
+
+        rm_resource_pool = None
+
+        self.async_rollout_manager = GKDAgentLoopManager(
+            config=self.config, worker_group=self.rollout_wg, rm_resource_pool=rm_resource_pool
+        )
+
+    def sync_rollout_weights(self):
+        assert not self.hybrid_engine
+        self.actor_wg.sync_rollout_weights()
+        ray.get(self.rollout_wg.sync_rollout_weights())
+
+    def _create_continuous_iterator(self):
+        """
+        Create a continuous data iterator across epoch
+        """
+        for epoch in range(self.config.trainer.total_epochs):
+            iterator = iter(self.train_dataloader)
+            for batch_dict in iterator:
+                yield epoch, batch_dict
+
+    async def _async_gen_next_batch(self, epoch, batch_dict, sync_before_generation=True):
+        """
+        Call parameter synchronization and asynchronous sequence generation.
+        """
+
+        batch: DataProto = DataProto.from_single_dict(batch_dict)
+        batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
+
+        # add uid to batch
+        batch.non_tensor_batch["uid"] = np.array(
+            [str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object
+        )
+
+        gen_batch = self._get_gen_batch(batch)
+        gen_batch.meta_info["global_steps"] = self.global_steps
+        # sync weights from actor to rollout
+        if sync_before_generation:
+            self.sync_rollout_weights()
+            await self.async_rollout_manager.clear_kv_cache()
+        # Call non-blocking rollout (worker method registered with blocking=False)
+        # async generation
+        timing_raw = {}
+        with marked_timer("generate_async", timing_raw, color="purple"):
+            gen_batch_output = await self.async_rollout_manager.generate_sequences_async(gen_batch)
+
+        return epoch, batch, gen_batch_output
+
+    async def _async_get_teacher_knowledge(self, gen_res):
+        """Asynchronously obtain teacher model knowledge for generated sequences.
+
+        This method retrieves generated sequences from the future object, adds response length metadata,
+        and asynchronously queries the teacher model for knowledge distillation. The teacher model's output
+        is set in the future object for subsequent processing.
+
+        Raises:
+            RuntimeError: If teacher client initialization fails or knowledge retrieval fails
+        """
+        epoch, batch, gen_batch_output = await gen_res
+        gen_batch_output.meta_info["response_length"] = self.config.data.max_response_length
+        teacher_batch_output = get_teacher_knowledge(gen_batch_output, self.teacher_client, self.n_server_workers,
+                                                     is_async=False)
+        return epoch, batch, gen_batch_output, teacher_batch_output
+
+    async def one_step_off_scheduler(self, continuous_iterator):
+        """One-step-off scheduler implementation (version 1) for GKD training with improved pipeline.
+
+        This scheduler optimizes the training pipeline by:
+        1. Overlapping rollout weight synchronization with teacher knowledge processing
+        2. Maintaining consistent timing measurement across iterations
+        3. Reducing idle time between generation and knowledge distillation phases
+
+        The scheduler maintains the following timing metrics:
+        - sync_rollout_weights: Time taken to synchronize rollout weights
+        - wait_prev_gen: Time waiting for previous generation to complete
+        - wait_prev_teacher: Time waiting for teacher knowledge to be ready
+
+        Args:
+            continuous_iterator: Iterator providing (epoch, batch_dict) tuples for training
+
+        Yields:
+            tuple: Contains (batch, gen_batch_output, teacher_batch_output, timing_metrics)
+                - batch: Original input batch data
+                - gen_batch_output: Generated sequences from main model
+                - teacher_batch_output: Knowledge distillation from teacher model
+                - timing_metrics: Dictionary of timing measurements
+        """
+        timing = {}
+        for i, (epoch, batch_dict) in enumerate(continuous_iterator):
+            if i == 0:
+                # sync weights and start first async rollout
+                with marked_timer("sync_rollout_weights", timing):
+                    rollout_future = asyncio.create_task(self._async_gen_next_batch(epoch, batch_dict))
+                # wait for previous rollout finish and start async generate teacher knowledge
+                with marked_timer("wait_prev_gen", timing):
+                    teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
+                # no yield here, so we will continue to the next loop and enter `else` block
+                continue
+            if i == 1:
+                # we don't need to sync weights here because we have not trained the actor yet
+                # start second async rollout
+                rollout_future = asyncio.create_task(
+                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False))
+                # wait for generating teacher knowledge finish
+                # and get previous result including rollout and teacher knowledge
+                with marked_timer("wait_prev_teacher", timing):
+                    result = await teacher_future
+                yield *result, timing
+
+                # start next step from here
+                timing = {}
+                # wait for previous rollout finish and start async generate teacher knowledge
+                with marked_timer("wait_prev_gen", timing):
+                    teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
+            else:
+                # sync weights and start next async rollout
+                with marked_timer("sync_rollout_weights", timing):
+                    rollout_future = asyncio.create_task(self._async_gen_next_batch(epoch, batch_dict))
+                # wait for generating teacher knowledge finish
+                # and get previous result including rollout and teacher knowledge
+                with marked_timer("wait_prev_teacher", timing):
+                    result = await teacher_future
+                yield *result, timing
+
+                # start next step from here
+                timing = {}
+                # wait for previous rollout finish and start async generate teacher knowledge
+                with marked_timer("wait_prev_gen", timing):
+                    teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
+
+        # for last step
+        with marked_timer("wait_prev_teacher", timing):
+            result = await teacher_future
+        yield *result, timing
+
+    def two_step_off_scheduler(self, continuous_iterator):
+        """Two-step-off scheduler implementation for GKD training with optimized pipeline.
+
+        This scheduler implements a double-buffered pipeline that overlaps:
+        1. Sequence generation with teacher knowledge distillation
+        2. Weight synchronization with previous batch processing
+
+        Key features:
+        - Maintains two parallel processing streams (current and previous batches)
+        - Overlaps computation and communication where possible
+        - Provides consistent timing metrics across iterations
+
+        Pipeline stages:
+        1. Initialization: Start first generation without teacher processing
+        2. Steady state: Alternate between processing teacher knowledge and starting new generation
+        3. Final state: Process last batch of teacher knowledge
+
+        Timing metrics collected:
+        - sync_rollout_weights: Time for weight synchronization between actor and rollout workers
+        - wait_prev_prev_teacher: Time waiting for teacher knowledge from two batches ago
+        - wait_prev_gen: Time waiting for previous generation to complete
+
+        Args:
+            continuous_iterator: Iterator providing (epoch, batch_dict) tuples for training
+
+        Yields:
+            tuple: Contains (batch, gen_batch_output, teacher_batch_output, timing_metrics)
+                - batch: Original input batch data
+                - gen_batch_output: Generated sequences from main model
+                - teacher_batch_output: Knowledge distillation from teacher model
+                - timing_metrics: Dictionary of timing measurements
+        """
+        timing = {}
+        for i, (epoch, batch_dict) in enumerate(continuous_iterator):
+            if i == 0:
+                with marked_timer("sync_rollout_weights", timing):
+                    rollout_future = asyncio.create_task(self._async_gen_next_batch(epoch, batch_dict))
+                continue
+            elif i == 1:
+                teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
+                rollout_future = asyncio.create_task(
+                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False))
+                continue
+            elif i == 2:
+                with marked_timer("wait_prev_prev_teacher", timing):
+                    result = await teacher_future
+                with marked_timer("wait_prev_gen", timing):
+                    teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
+
+                rollout_future = asyncio.create_task(
+                    self._async_gen_next_batch(epoch, batch_dict, sync_before_generation=False))
+                yield *result, timing
+                timing = {}
+            else:
+                with marked_timer("wait_prev_prev_teacher", timing):
+                    result = await teacher_future
+                with marked_timer("wait_prev_gen", timing):
+                    teacher_future = asyncio.create_task(self._async_get_teacher_knowledge(rollout_future))
+                with marked_timer("sync_rollout_weights", timing):
+                    rollout_future = asyncio.create_task(self._async_gen_next_batch(epoch, batch_dict))
+                yield *result, timing
+                timing = {}
+
+        # for second to last step
+        with marked_timer("wait_prev_prev_teacher", timing):
+            result = await teacher_future
+        with marked_timer("wait_prev_gen", timing):
+            teacher_future = self._async_get_teacher_knowledge(rollout_future)
+        yield *result, timing
+
+        # for last step
+        with marked_timer("wait_prev_prev_teacher", timing):
+            result = await teacher_future
+        yield *result, timing
+
+    async def fit(self):
+        """
+        The training loop of PPO.
+        The driver process only need to call the compute functions of the worker group through RPC
+        to construct the PPO dataflow.
+        The light-weight advantage computation is done on the driver process.
+        """
+        from omegaconf import OmegaConf
+
+        from verl.utils.tracking import Tracking
+
+        logger = Tracking(
+            project_name=self.config.trainer.project_name,
+            experiment_name=self.config.trainer.experiment_name,
+            default_backend=self.config.trainer.logger,
+            config=OmegaConf.to_container(self.config, resolve=True),
+        )
+
+        self.global_steps = 0
+
+        # load checkpoint before doing anything
+        self._load_checkpoint()
+
+        # add tqdm
+        progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")
+
+        # we start from step 1
+        self.global_steps += 1
+        max_steps_duration = 0
+
+        # Pre-warm: submit the first rollout
+        continuous_iterator = self._create_continuous_iterator()
+
+        scheduler_type = self.config.trainer.scheduler
+
+        if scheduler_type == "one_step_off":
+            scheduler = self.one_step_off_scheduler(continuous_iterator)
+        elif scheduler_type == "two_step_off":
+            scheduler = self.two_step_off_scheduler(continuous_iterator)
+        else:
+            raise TypeError(f"unrecognized scheduler type: {scheduler_type}")
+
+        # Main loop
+        while True:
+            do_profile = (
+                self.global_steps in self.config.global_profiler.steps
+                if self.config.global_profiler.steps is not None
+                else False
+            )
+            if do_profile:
+                self.rollout_wg.start_profile()
+                self.actor_wg.start_profile()
+
+            metrics = {}
+            timing_raw = {}
+            is_last_step = self.global_steps >= self.total_training_steps
+
+            with marked_timer("step", timing_raw):
+                _, batch, gen_batch_output, teacher_batch_output, schedule_timing = await scheduler.__anext__()
+                if teacher_batch_output is None:
+                    # save model
+                    if self.config.trainer.save_freq > 0 and (
+                      is_last_step or self.global_steps % self.config.trainer.save_freq == 0
+                    ):
+                        self._save_checkpoint()
+                    print("Error in getting teacher knowledge. Skip this batch.")
+                    progress_bar.update(1)
+                    self.global_steps += 1
+                    if is_last_step:
+                        progress_bar.close()
+                        return
+                    continue
+
+                timing_raw.update(schedule_timing)
+
+                gen_timing = gen_batch_output.meta_info.pop("timing", {})
+                for k, v in gen_timing.items():
+                    if isinstance(v, list):
+                        array_v = np.array(v)
+                        timing_raw[k + "_mean"] = array_v.mean().item()
+                        timing_raw[k + "_min"] = array_v.min().item()
+                        timing_raw[k + "_max"] = array_v.max().item()
+                        timing_raw[k] = array_v.max().item()
+                    else:
+                        timing_raw[k] = v
+
+                timing_raw.update(teacher_batch_output.meta_info.pop("timing"))
+
+                # Compute statistics of generated response lengths distribution
+                response_lens = (
+                    (gen_batch_output.batch["responses"] != self.tokenizer.pad_token_id).sum(dim=-1).tolist()
+                )
+                metrics.update(
+                    {
+                        "response_seq_len/average": sum(response_lens) / len(response_lens),
+                        "response_seq_len/max": max(response_lens),
+                        "response_seq_len/min": min(response_lens),
+                        "response_seq_len/max_count": response_lens.count(max(response_lens)),
+                        "response_seq_len/min_count": response_lens.count(min(response_lens)),
+                    }
+                )
+
+                # Merge generated outputs back
+                batch = batch.union(gen_batch_output)
+
+                # Debug print
+                one_attention_mask = batch.batch["attention_mask"][0].to(torch.bool)
+                one_sentence = batch.batch["input_ids"][0]
+                print("INFO:", "generate text done.")
+                print("DEBUG:", self.tokenizer.decode(one_sentence[one_attention_mask].tolist()))
+
+                # compute global_valid tokens
+                batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
+
+                batch = batch.union(teacher_batch_output)
+
+                # update actor
+                with marked_timer("update_actor", timing_raw, color="red"):
+                    actor_output = self.actor_wg.update_actor(batch)
+
+                print("INFO:", "update actor done.")
+                actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
+                metrics.update(actor_output_metrics)
+
+                # save model
+                if self.config.trainer.save_freq > 0 and (
+                  is_last_step or self.global_steps % self.config.trainer.save_freq == 0
+                ):
+                    with marked_timer("save_checkpoint", timing_raw, color="green"):
+                        self._save_checkpoint()
+
+            # Metrics and bookkeeping
+            steps_duration = timing_raw["step"]
+            max_steps_duration = max(max_steps_duration, steps_duration)
+            # training metrics
+            metrics["training/global_step"] = self.global_steps
+            n_gpus = self.resource_pool_manager.get_n_gpus()
+            metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+            # TODO: implement actual tflpo and theoretical tflpo
+            metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+
+            # this is experimental and may be changed/removed in the future in favor of a general-purpose one
+            if isinstance(self.train_dataloader.sampler, AbstractCurriculumSampler):
+                self.train_dataloader.sampler.update(batch=batch)
+
+            # TODO: make a canonical logger that supports various backend
+            logger.log(data=metrics, step=self.global_steps)
+
+            progress_bar.update(1)
+            self.global_steps += 1
+
+            if do_profile:
+                self.rollout_wg.stop_profile()
+                self.actor_wg.stop_profile()
+
+            if is_last_step:
+                progress_bar.close()
+                return

--- a/gkd_ascend/ray_trainer.py
+++ b/gkd_ascend/ray_trainer.py
@@ -105,6 +105,7 @@ class OnPolicyDistillTrainer(RayPPOTrainer):
         self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
         assert not self.hybrid_engine
 
+        self.use_critic = False
         self.role_worker_mapping = role_worker_mapping
         self.resource_pool_manager = resource_pool_manager
         self.ray_worker_group_cls = ray_worker_group_cls

--- a/gkd_ascend/run_4b_fsdp.sh
+++ b/gkd_ascend/run_4b_fsdp.sh
@@ -1,0 +1,82 @@
+set -x
+
+export VERL_LOGGING_LEVEL=INFO
+
+
+train_files=openai-gsm8k/train.parquet
+test_files=openai-gsm8k/test.parquet
+
+# model
+HF_MODEL_PATH=/path/to/Qwen3-4B/
+
+INFER_TP=1
+
+# train config
+scheduler=one_step_off
+NODES=1
+
+# 2. run the script
+python3 -u -m main_gkd --config-path=config --config-name on_policy_distill_trainer \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.prompt_key="prompt" \
+    data.train_batch_size=32 \
+    data.max_prompt_length=512 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=true \
+    data.truncation='error' \
+    data.trust_remote_code=true \
+    data.filter_overlong_prompts_workers=32 \
+    data.return_raw_chat=true \
+    +data.apply_chat_template_kwargs.enable_thinking=false \
+    actor_rollout_ref.teacher.server_ip=127.0.0.1 \
+    actor_rollout_ref.teacher.server_port=15555 \
+    actor_rollout_ref.teacher.n_server_workers=1 \
+    actor_rollout_ref.model.path=$HF_MODEL_PATH \
+    actor_rollout_ref.model.trust_remote_code=true \
+    actor_rollout_ref.model.enable_gradient_checkpointing=true \
+    actor_rollout_ref.model.enable_activation_offload=true \
+    actor_rollout_ref.model.use_remove_padding=false \
+    +actor_rollout_ref.model.override_config.attn_implementation=eager \
+    actor_rollout_ref.actor.strategy=fsdp \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.fsdp_config.forward_prefetch=true \
+    actor_rollout_ref.actor.fsdp_config.param_offload=false \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=false \
+    actor_rollout_ref.actor.fsdp_config.use_orig_params=false \
+    actor_rollout_ref.actor.optim.lr=4e-5 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=0 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.02 \
+    actor_rollout_ref.actor.use_dynamic_bsz=false \
+    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_kl_loss=false \
+    actor_rollout_ref.actor.use_torch_compile=false \
+    actor_rollout_ref.actor.checkpoint.save_contents=["model","optimizer","extra","hf_model"] \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.top_p=0.99 \
+    actor_rollout_ref.rollout.top_k=-1 \
+    actor_rollout_ref.rollout.n=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$INFER_TP \
+    actor_rollout_ref.rollout.load_format='auto' \
+    actor_rollout_ref.rollout.free_cache_engine=false \
+    actor_rollout_ref.rollout.enforce_eager=true \
+    algorithm.use_kl_in_reward=false \
+    trainer.device=npu \
+    trainer.logger='["console","tensorboard"]' \
+    trainer.project_name='verl_fsdp_examples' \
+    trainer.experiment_name='qwen-4b-distill' \
+    trainer.n_gpus_per_node=4 \
+    trainer.nnodes=$NODES \
+    rollout.n_gpus_per_node=2 \
+    rollout.nnodes=$NODES \
+    trainer.balance_batch=false \
+    trainer.scheduler=$scheduler \
+    trainer.save_freq=5 \
+    trainer.test_freq=-1 \
+    trainer.val_before_train=false \
+    trainer.total_training_steps=10 \
+    trainer.total_epochs=1 $@

--- a/gkd_ascend/run_4b_megatron.sh
+++ b/gkd_ascend/run_4b_megatron.sh
@@ -1,0 +1,84 @@
+set -x
+
+export VERL_LOGGING_LEVEL=INFO
+
+
+train_files=openai-gsm8k/train.parquet
+test_files=openai-gsm8k/test.parquet
+
+# model
+HF_MODEL_PATH=/path/to/Qwen3-4B/
+
+INFER_TP=1
+
+# train config
+scheduler=one_step_off
+NODES=1
+PP=1
+TP=4
+EP=1
+ETP=1
+INFER_TP=1
+
+# 2. run the script
+python3 -m main_gkd --config-path=config --config-name on_policy_distill_megatron_trainer \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.prompt_key="prompt" \
+    data.train_batch_size=32 \
+    data.max_prompt_length=512 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=true \
+    data.truncation='error' \
+    data.trust_remote_code=true \
+    data.filter_overlong_prompts_workers=32 \
+    data.return_raw_chat=true \
+    +data.apply_chat_template_kwargs.enable_thinking=false \
+    actor_rollout_ref.teacher.server_ip=127.0.0.1 \
+    actor_rollout_ref.teacher.server_port=15555 \
+    actor_rollout_ref.teacher.n_server_workers=1 \
+    actor_rollout_ref.model.path=$HF_MODEL_PATH \
+    actor_rollout_ref.model.trust_remote_code=true \
+    actor_rollout_ref.model.enable_gradient_checkpointing=true \
+    actor_rollout_ref.actor.megatron.use_mbridge=False \
+    actor_rollout_ref.actor.megatron.param_offload=False \
+    actor_rollout_ref.actor.megatron.grad_offload=true \
+    actor_rollout_ref.actor.megatron.optimizer_offload=true \
+    actor_rollout_ref.actor.megatron.sequence_parallel=false \
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=$PP \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=$TP \
+    actor_rollout_ref.actor.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.actor.megatron.expert_tensor_parallel_size=$ETP \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.sequence_parallel=false \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn=true \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    +actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    +actor_rollout_ref.actor.distill_loss.name=kl \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.actor.checkpoint.save_contents=["model","optimizer","extra","hf_model"] \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.top_p=0.99 \
+    actor_rollout_ref.rollout.top_k=-1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$INFER_TP \
+    actor_rollout_ref.rollout.load_format='auto' \
+    actor_rollout_ref.rollout.free_cache_engine=false \
+    actor_rollout_ref.rollout.enforce_eager=true \
+    algorithm.use_kl_in_reward=False \
+    trainer.device=npu \
+    trainer.logger=['console'] \
+    trainer.project_name='verl_examples_0514' \
+    trainer.experiment_name='qwen-distill' \
+    trainer.n_gpus_per_node=4 \
+    trainer.nnodes=$NODES \
+    rollout.n_gpus_per_node=2 \
+    rollout.nnodes=$NODES \
+    trainer.save_freq=5 \
+    trainer.test_freq=-1 \
+    trainer.val_before_train=False \
+    trainer.total_training_steps=10 \
+    trainer.total_epochs=1 $@

--- a/gkd_ascend/teacher/__init__.py
+++ b/gkd_ascend/teacher/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .client import TeacherClient
+
+__all__ = ["TeacherClient"]

--- a/gkd_ascend/teacher/client.py
+++ b/gkd_ascend/teacher/client.py
@@ -1,0 +1,208 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import queue
+import random
+import threading
+from concurrent.futures import Future
+from contextlib import nullcontext
+from datetime import datetime
+
+import torch
+import zmq
+from codetiming import Timer
+
+try:
+    from .utils import deserialize, serialize
+except ImportError:
+    from utils import deserialize, serialize
+
+DEBUG = False
+
+
+def check_if_invalid(topk_logps, inputs):
+    is_valid = True
+    reason = ""
+    for x in topk_logps:
+        if x.isnan().any():
+            is_valid = False
+            reason = "nan"
+            break
+        elif x.isinf().any():
+            is_valid = False
+            reason = "inf"
+            break
+        elif (x == 0).any():
+            is_valid = False
+            reason = "zero"
+            break
+    if not is_valid:
+        if isinstance(inputs, torch.Tensor):
+            inputs = inputs.tolist()
+        with open("teacher_debug.log", "a") as f:
+            f.write("{}\n".format(datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
+            f.write(f"{reason}\n")
+            f.write(f"{str(inputs)}\n")
+
+
+class TeacherClient:
+    def __init__(
+        self,
+        server_ip,
+        server_port,
+        num_microbatches=1,
+        max_tokens=1,
+        n_server_workers=1,
+        temperature=1,
+        only_response=False,
+        max_seq_len=None,
+    ) -> None:
+        self.server_ip = server_ip
+        self.server_port = server_port
+        self.num_microbatches = num_microbatches
+        self.n_server_workers = n_server_workers
+        self.max_tokens = max_tokens
+        self.task_queue = queue.Queue()
+        self.mutex = threading.Lock() if n_server_workers > 1 else nullcontext()
+        self.context = zmq.Context()
+        self.temperature = temperature
+        self.only_response = only_response
+        self.max_seq_len = max_seq_len
+        self._run()
+
+    def bg_task(self):
+        socket = self.context.socket(zmq.REQ)
+        socket.connect(f"tcp://{self.server_ip}:{self.server_port}")
+        socket.setsockopt(zmq.LINGER, 0)
+        socket.setsockopt(zmq.RCVTIMEO, 600000)  # 接收超时 30 分钟
+
+        while True:
+            futures = []
+            inputs = []
+            batch = []
+            try:
+                with self.mutex:
+                    for _ in range(self.num_microbatches):
+                        future, data = self.task_queue.get()
+                        if DEBUG:
+                            inputs.append(data)
+                        futures.append(future)
+                        batch.extend(data.tolist() if isinstance(data, torch.Tensor) else data)
+
+                if self.max_seq_len:
+                    max_tokens = [min(self.max_tokens, self.max_seq_len - len(prompt)) for prompt in batch]
+                    request = {"prompt_token_ids": batch, "max_tokens": max_tokens}
+                else:
+                    request = {"prompt_token_ids": batch, "max_tokens": self.max_tokens}
+                if self.temperature:
+                    request["temperature"] = self.temperature
+                if self.only_response:
+                    request["only_response"] = True
+
+                socket.send(serialize(request))
+                raw = socket.recv()
+                response = deserialize(raw)
+
+                if isinstance(response, dict) and response.get("status") == "error":
+                    reason = response.get("reason", "unknown")
+                    err = RuntimeError(f"Teacher error: {reason}")
+                    for f in futures:
+                        f.set_exception(err)
+                    continue
+
+                required = ("responses", "teacher_topk_logprobs", "teacher_topk_indices")
+                for k in required:
+                    if k not in response:
+                        raise RuntimeError(f"Invalid response: missing key '{k}'")
+
+                total = len(response["teacher_topk_logprobs"])
+                if self.num_microbatches <= 0 or total % self.num_microbatches != 0:
+                    raise RuntimeError(f"Size mismatch: total={total}, num_microbatches={self.num_microbatches}")
+
+                mbs = total // self.num_microbatches
+                for i, future in enumerate(futures):
+                    s, e = i * mbs, (i + 1) * mbs
+                    responses = response["responses"][s:e]
+                    teacher_topk_logps = response["teacher_topk_logprobs"][s:e]
+                    if DEBUG:
+                        check_if_invalid(teacher_topk_logps, inputs[i])
+                    teacher_topk_indices = response["teacher_topk_indices"][s:e]
+                    future.set_result((responses, teacher_topk_logps, teacher_topk_indices))
+
+            except zmq.Again:
+                err = TimeoutError(f"Timeout waiting for server {self.server_ip}:{self.server_port}")
+                for f in futures:
+                    f.set_exception(err)
+                continue
+            except Exception as e:
+                for f in futures:
+                    try:
+                        f.set_exception(e)
+                    except Exception:
+                        pass
+                continue
+
+    def _run(self):
+        for _ in range(self.n_server_workers):
+            threading.Thread(target=self.bg_task, daemon=True).start()
+
+    def submit(self, data):
+        future = Future()
+        self.task_queue.put((future, data))
+        return future
+
+    def __del__(self):
+        self.context.destroy()
+
+
+if __name__ == "__main__":
+    gbs = 128
+    n_gps = 1
+    mbs = 2
+    seq_len = 4096
+
+    prompt_lens = (n_gps * gbs) * [seq_len]
+
+    tc = TeacherClient(
+        server_ip="127.0.0.1", server_port=15555, num_microbatches=gbs // mbs, n_server_workers=1, only_response=False
+    )
+
+    prompt_token_ids = []
+
+    for pl in prompt_lens:
+        prompt_token_ids.append([random.randint(1, 99999) for j in range(pl)])
+
+    with Timer(name="get_topk_logprobs", initial_text=True):
+        futures = []
+        for i in range(0, n_gps * gbs, mbs):
+            futures.append(tc.submit(prompt_token_ids[i : i + mbs]))
+
+        for future in futures:
+            responses, teacher_topk_logprobs, teacher_topk_indices = future.result()
+
+            print(len(teacher_topk_logprobs), len(teacher_topk_indices))
+
+            assert len(responses) == mbs
+            assert len(teacher_topk_logprobs) == mbs
+            assert len(teacher_topk_indices) == mbs
+
+            assert all(x.shape == y.shape for x, y in zip(teacher_topk_logprobs, teacher_topk_indices, strict=False))
+            out_lens = [x.shape[0] for x in teacher_topk_logprobs]
+            out_dims = [x.shape[1] for x in teacher_topk_logprobs]
+            assert all(out_len == seq_len for out_len in out_lens)
+            assert all(out_dim == 256 for out_dim in out_dims)
+            assert all(x.dtype == torch.float32 for x in teacher_topk_logprobs), [
+                x.dtype for x in teacher_topk_logprobs
+            ]
+            assert all(x.dtype == torch.int32 for x in teacher_topk_indices)
+            assert all(x.dtype == torch.int32 for x in responses)

--- a/gkd_ascend/teacher/join_server_vllm_engine.sh
+++ b/gkd_ascend/teacher/join_server_vllm_engine.sh
@@ -1,0 +1,31 @@
+export PROXY_FRONTEND_PORT=15555
+export PROXY_BACKEND_PORT=15556
+
+PROXY_IP="127.0.0.1"
+BACKEND=vllm_engine
+CKPT_PATH="/path/to/TEACHER_MODEL/"
+
+wait_server_ready() {
+    server=$1
+    ip=$2
+    port=$3
+    while true; do
+        echo "wait $server server ready at $ip:$port..."
+        result=`echo -e "\n" | telnet $ip $port 2> /dev/null | grep Connected | wc -l`
+        if [ $result -eq 1 ]; then
+            break
+        else
+            sleep 1
+        fi
+    done
+}
+
+ps -ef | grep "python worker.py" | grep -v grep | awk -F ' ' '{print $2}' | xargs -r kill -9
+
+wait_server_ready proxy $PROXY_IP $PROXY_BACKEND_PORT
+
+echo "teacher proxy is ready"
+
+nohup python worker.py --backend $BACKEND --proxy-addr $PROXY_IP:$PROXY_BACKEND_PORT --tp-size 8 --n-logprobs 256 --ckpt-path $CKPT_PATH --max-model-len 8192 --dtype bfloat16 &> worker.log &
+
+echo "teacher server is ready"

--- a/gkd_ascend/teacher/proxy.py
+++ b/gkd_ascend/teacher/proxy.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import zmq
+
+context = zmq.Context()
+
+frontend_listen_port = os.environ.get("PROXY_FRONTEND_PORT")
+backend_listen_port = os.environ.get("PROXY_BACKEND_PORT")
+
+assert frontend_listen_port is not None, "PROXY_FRONTEND_PORT is not set"
+assert backend_listen_port is not None, "PROXY_BACKEND_PORT is not set"
+
+# 创建前端 ROUTER 套接字并绑定到客户端连接地址
+frontend = context.socket(zmq.ROUTER)
+frontend.bind(f"tcp://*:{frontend_listen_port}")
+
+# 创建后端 DEALER 套接字并绑定到服务端连接地址
+backend = context.socket(zmq.DEALER)
+backend.bind(f"tcp://*:{backend_listen_port}")
+
+# 创建 poller 用于同时监听多个套接字
+poller = zmq.Poller()
+poller.register(frontend, zmq.POLLIN)
+poller.register(backend, zmq.POLLIN)
+
+print("proxy is running...")
+
+while True:
+    socks = dict(poller.poll())
+
+    if frontend in socks:
+        # 从 ROUTER 接收来自客户端的消息（multipart 消息）
+        parts = frontend.recv_multipart()
+        # print(f"收到客户端消息: {parts}")
+
+        # 将完整的 multipart 消息转发给 DEALER
+        backend.send_multipart(parts)
+
+    if backend in socks:
+        # 从 DEALER 接收来自服务端的回复
+        reply_parts = backend.recv_multipart()
+        # print(f"收到服务端回复: {reply_parts}")
+
+        # 将回复转发回原始客户端（假设第一个部分是客户端 ID）
+        frontend.send_multipart(reply_parts)

--- a/gkd_ascend/teacher/start_server_vllm_api.sh
+++ b/gkd_ascend/teacher/start_server_vllm_api.sh
@@ -1,0 +1,52 @@
+export PROXY_FRONTEND_PORT=15555
+export PROXY_BACKEND_PORT=15556
+
+BACKEND=vllm_api
+
+MODEL_API="http://0.0.0.0:8000"
+SERVE_MODEL_NAME="SERVE_MODEL_NAME"
+
+wait_server_ready() {
+    server=$1
+    ip=$2
+    port=$3
+    while true; do
+        echo "wait $server server ready at $ip:$port..."
+        result=`echo -e "\n" | telnet $ip $port 2> /dev/null | grep Connected | wc -l`
+        if [ $result -eq 1 ]; then
+            break
+        else
+            sleep 1
+        fi
+    done
+}
+
+wait_api_ready() {
+    local api_base=$1
+    echo "Waiting for vLLM serve API at $api_base..."
+    while true; do
+        if curl -s -o /dev/null -w "%{http_code}" "$api_base/health" | grep -q "200"; then
+            break
+        else
+            sleep 5
+        fi
+    done
+}
+
+ps -ef | grep "python proxy.py" | grep -v grep | awk -F ' ' '{print $2}' | xargs -r kill -9
+ps -ef | grep "python worker.py" | grep -v grep | awk -F ' ' '{print $2}' | xargs -r kill -9
+
+wait_api_ready $MODEL_API
+
+echo "vLLM serve API is ready"
+
+nohup python proxy.py &> proxy.log &
+
+wait_server_ready proxy localhost $PROXY_BACKEND_PORT
+
+echo "teacher proxy is ready"
+
+nohup python worker.py --backend $BACKEND --n-logprobs 256 --api-base $MODEL_API --serve-model $SERVE_MODEL_NAME &> worker.log &
+echo "start teacher worker"
+
+echo "teacher server is ready"

--- a/gkd_ascend/teacher/start_server_vllm_engine.sh
+++ b/gkd_ascend/teacher/start_server_vllm_engine.sh
@@ -1,0 +1,34 @@
+export PROXY_FRONTEND_PORT=15555
+export PROXY_BACKEND_PORT=15556
+
+BACKEND=vllm_engine
+CKPT_PATH="/path/to/TEACHER_MODEL/"
+
+wait_server_ready() {
+    server=$1
+    ip=$2
+    port=$3
+    while true; do
+        echo "wait $server server ready at $ip:$port..."
+        result=`echo -e "\n" | telnet $ip $port 2> /dev/null | grep Connected | wc -l`
+        if [ $result -eq 1 ]; then
+            break
+        else
+            sleep 1
+        fi
+    done
+}
+
+ps -ef | grep "python proxy.py" | grep -v grep | awk -F ' ' '{print $2}' | xargs -r kill -9
+ps -ef | grep "python worker.py" | grep -v grep | awk -F ' ' '{print $2}' | xargs -r kill -9
+
+nohup python proxy.py &> proxy.log &
+
+wait_server_ready proxy localhost $PROXY_BACKEND_PORT
+
+echo "teacher proxy is ready"
+
+nohup python worker.py --backend $BACKEND --tp-size 1 --n-logprobs 256 --ckpt-path $CKPT_PATH --max-model-len 8192 --dtype bfloat16 &> worker.log &
+echo "start teacher worker"
+
+echo "teacher server is ready"

--- a/gkd_ascend/teacher/utils.py
+++ b/gkd_ascend/teacher/utils.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+
+import torch
+
+
+def chunk_list(lst, n_chunks):
+    """Split a list into chunks of equal length"""
+    size = len(lst) // n_chunks
+    for i, start in enumerate(range(0, len(lst), size)):
+        if i == n_chunks - 1:
+            yield lst[start:]
+            return
+        else:
+            yield lst[start : start + size]
+
+
+def serialize(data):
+    buffer = io.BytesIO()
+    torch.save(data, buffer)
+    return buffer.getbuffer()
+
+
+def deserialize(message):
+    buffer = io.BytesIO(message)
+    return torch.load(buffer)
+
+
+if __name__ == "__main__":
+    lst = list(range(12))
+    sub_lsts = list(chunk_list(lst, 3))
+
+    assert len(sub_lsts) == 3
+    assert sub_lsts[0] == [0, 1, 2, 3]
+    assert sub_lsts[1] == [4, 5, 6, 7]
+    assert sub_lsts[2] == [8, 9, 10, 11]
+
+    lst = list(range(11))
+    sub_lsts = list(chunk_list(lst, 3))
+    assert len(sub_lsts) == 3
+    assert sub_lsts[0] == [0, 1, 2]
+    assert sub_lsts[1] == [3, 4, 5]
+    assert sub_lsts[2] == [6, 7, 8, 9, 10]
+
+    lst = list(range(11))
+    sub_lsts = list(chunk_list(lst, 1))
+    assert len(sub_lsts) == 1
+    assert sub_lsts[0] == list(range(11))

--- a/gkd_ascend/teacher/vllm_api_backend.py
+++ b/gkd_ascend/teacher/vllm_api_backend.py
@@ -1,0 +1,333 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Backend for connecting to an existing vLLM serve API server.
+
+This allows using a separate vLLM inference server (started via `vllm serve`)
+as the teacher model backend, instead of embedding the vLLM engine in the worker.
+
+Usage:
+    # Start vLLM server separately:
+    vllm serve Qwen/Qwen2.5-72B --tensor-parallel-size 8 --port 8000
+
+    # Start teacher worker connecting to the server:
+    python worker.py --backend vllm_serve --api-base http://localhost:8000 --n-logprobs 256
+"""
+
+from typing import List, Optional, Union
+from urllib.parse import urljoin
+
+import requests
+import torch
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+class VLLMAPIBackend:
+    """
+    Backend that connects to an existing vLLM serve API server.
+
+    This backend uses the OpenAI-compatible API provided by vLLM serve
+    to generate tokens and retrieve logprobs for knowledge distillation.
+
+    Args:
+        api_base: Base URL of the vLLM serve API (e.g., "http://localhost:8000")
+        n_logprobs: Number of top-k logprobs to return (default: 256)
+        max_batch_size: Maximum batch size per API call (default: None, auto-compute)
+        timeout: Request timeout in seconds (default: 600)
+        max_retries: Maximum number of retries on failure (default: 3)
+    """
+
+    def __init__(
+      self,
+      api_base: str,
+      n_logprobs: int = 256,
+      timeout: int = 1800,
+      max_retries: int = 3,
+      model: str = "default"
+    ):
+        self.api_base = api_base.rstrip("/")
+        self.n_logprobs = n_logprobs
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.model = model
+        # Verify server is reachable
+        self._health_check()
+
+        print(f"Connected to vLLM serve at {api_base}, n_logprobs={n_logprobs}")
+
+    def _health_check(self):
+        """Check if the vLLM server is healthy."""
+        url = urljoin(self.api_base, "/health")
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.get(url, timeout=10)
+                if response.status_code == 200:
+                    return
+            except requests.exceptions.RequestException as e:
+                if attempt == self.max_retries - 1:
+                    raise RuntimeError(f"Failed to connect to vLLM server at {self.api_base}: {e}")
+                time.sleep(1)
+
+        raise RuntimeError(f"vLLM server at {self.api_base} is not healthy")
+
+    def _call_completions_api(
+      self,
+      prompt_token_ids: List[List[int]],
+      temperature: float,
+      max_tokens: Union[int, List[int]],
+      only_response: bool,
+    ) -> dict:
+        """Call the vLLM completions API with logprobs."""
+        url = urljoin(self.api_base, "/v1/completions")
+
+        # Build the request payload
+        # vLLM supports passing token IDs directly via the 'prompt' field as a list
+        if len(prompt_token_ids) == 1:
+            # Single prompt
+            payload = {
+                "model": self.model,  # vLLM serve uses the loaded model
+                "prompt": prompt_token_ids[0],
+                "temperature": temperature,
+                "max_tokens": max_tokens if isinstance(max_tokens, int) else max_tokens[0],
+                "logprobs": self.n_logprobs,
+                "prompt_logprobs": None if only_response else self.n_logprobs,  # Get prompt logprobs if needed
+                "echo": not only_response,
+                "return_tokens_as_token_ids": True,
+                "return_token_ids": True,
+            }
+        else:
+            # Batch of prompts
+            if isinstance(max_tokens, list):
+                # vLLM doesn't support per-prompt max_tokens in batch mode
+                # Use the maximum
+                max_tokens = max(max_tokens)
+
+            payload = {
+                "model": self.model,
+                "prompt": prompt_token_ids,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "logprobs": self.n_logprobs,
+                "prompt_logprobs": None if only_response else self.n_logprobs,  # Get prompt logprobs if needed
+                "echo": not only_response,
+                "return_tokens_as_token_ids": True,
+                "return_token_ids": True,
+            }
+
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.post(url, json=payload, timeout=self.timeout)
+                if response.status_code == 200:
+                    return response.json()
+                else:
+                    error_msg = response.text
+                    if attempt == self.max_retries - 1:
+                        raise RuntimeError(f"vLLM API error: {response.status_code} - {error_msg}")
+                    time.sleep(1)
+            except requests.exceptions.RequestException as e:
+                if attempt == self.max_retries - 1:
+                    raise RuntimeError(f"vLLM API request failed: {e}")
+                time.sleep(1)
+
+        raise RuntimeError("Failed to get response from vLLM API")
+
+    def _process_logprobs(self, logprobs_data: dict, token_idx: int = -1):
+        """
+        Extract top-k logprobs from vLLM API response.
+
+        Args:
+            logprobs_data: The logprobs dict from API response
+            token_idx: Index of the token to extract logprobs for (-1 for all tokens)
+
+        Returns:
+            Tuple of (topk_logprobs tensor, topk_indices tensor)
+        """
+        if logprobs_data is None or "top_logprobs" not in logprobs_data:
+            return None, None
+
+        top_logprobs = logprobs_data["top_logprobs"]
+
+        # top_logprobs is a list of dicts: [{token_id: logprob, ...}, ...]
+        all_logprobs = []
+        all_indices = []
+
+        for token_pos in top_logprobs[1:]:
+
+            token_dict = token_pos  # {token_id_str: logprob, ...}
+            # Convert to sorted list by logprob (descending)
+            items = sorted(token_dict.items(), key=lambda x: x[1], reverse=True)
+
+            # Take top-k
+            topk_items = items[: self.n_logprobs]
+
+            logprobs = []
+            indices = []
+            for token_id_str, logprob in topk_items:
+                if token_id_str.startswith("token_id:"):
+                    token_id_str = token_id_str.split(":")[1]
+                indices.append(int(token_id_str))
+                logprobs.append(logprob)
+
+            # Pad if necessary
+            while len(logprobs) < self.n_logprobs:
+                logprobs.append(0.0)
+                indices.append(0)
+
+            all_logprobs.append(logprobs)
+            all_indices.append(indices)
+
+        return (
+            torch.tensor(all_logprobs, dtype=torch.float32),
+            torch.tensor(all_indices, dtype=torch.int32),
+        )
+
+    def get_topk_logprobs(
+      self,
+      prompt_token_ids: List[List[int]],
+      temperature: float = 0.8,
+      max_new_tokens: Union[int, List[int]] = 1,
+      only_response: bool = False,
+    ):
+        """
+        Get top-k logprobs for given prompts using vLLM serve API.
+
+        When n_logprobs is large, storing logprobs for all positions across a large batch
+        can cause OOM on the vLLM server side. This method splits the batch into smaller
+        chunks and processes them sequentially, freeing memory between chunks.
+
+        Memory estimation: batch_size * seq_len * n_logprobs * 4 bytes * 2 (logprobs + indices)
+        Example: 32 * 4096 * 10000 * 8 ≈ 10.5 GB
+
+        Args:
+            prompt_token_ids: List of token ID lists
+            temperature: Sampling temperature
+            max_new_tokens: Maximum new tokens to generate (int or list of ints)
+            only_response: If True, only return logprobs for response tokens
+
+        Returns:
+            responses: List of response token tensors
+            teacher_topk_logprobs: List of logprob tensors
+            teacher_topk_indices: List of index tensors
+        """
+
+        batch_size = len(prompt_token_ids)
+
+        def process_single(idx):
+            single_prompt = [prompt_token_ids[idx]]
+            single_max_new_tokens = max_new_tokens[idx] if isinstance(max_new_tokens, list) else max_new_tokens
+            # Call API
+            api_response = self._call_completions_api(
+                single_prompt, temperature, single_max_new_tokens, only_response
+            )
+            return idx, single_prompt, api_response
+
+        results = [None] * batch_size
+
+        with ThreadPoolExecutor(max_workers=batch_size) as executor:
+            futures = {executor.submit(process_single, i): i for i in range(batch_size)}
+            for future in as_completed(futures):
+                idx, single_prompt, api_response = future.result()
+                results[idx] = (single_prompt, api_response)
+
+        responses, teacher_topk_logprobs, teacher_topk_indices = [], [], []
+
+        for single_prompt, api_response in results:
+
+            # Process response
+            choices = api_response.get("choices", [])
+            choice = choices[0] if choices else {}
+
+            response_token_ids = choice.get("token_ids")
+
+            if response_token_ids:
+                response_tensor = torch.tensor(response_token_ids, dtype=torch.int32)
+            else:
+                response_tensor = torch.tensor([], dtype=torch.int32)
+
+            responses.append(response_tensor)
+
+            # Extract logprobs
+            logprobs_data = choice.get("logprobs")
+            if logprobs_data and self.n_logprobs > 0:
+                # Get response logprobs
+                response_topk_logps, response_topk_indices = self._process_logprobs(logprobs_data)
+
+                if response_topk_logps is not None:
+                    if only_response:
+                        teacher_topk_logprobs.append(response_topk_logps)
+                        teacher_topk_indices.append(response_topk_indices)
+                    else:
+                        # Get prompt logprobs from separate field
+                        prompt_logprobs_data = choice.get("prompt_logprobs")
+                        if prompt_logprobs_data:
+                            prompt_topk_logps, prompt_topk_indices = self._process_logprobs(prompt_logprobs_data)
+                            if prompt_topk_logps is not None:
+                                combined_logps = torch.vstack([prompt_topk_logps, response_topk_logps])
+                                combined_indices = torch.vstack([prompt_topk_indices, response_topk_indices])
+                                teacher_topk_logprobs.append(combined_logps)
+                                teacher_topk_indices.append(combined_indices)
+                            else:
+                                # Fallback: only response logprobs available
+                                teacher_topk_logprobs.append(response_topk_logps)
+                                teacher_topk_indices.append(response_topk_indices)
+                        else:
+                            # No prompt logprobs available, use response only
+                            teacher_topk_logprobs.append(response_topk_logps)
+                            teacher_topk_indices.append(response_topk_indices)
+                else:
+                    teacher_topk_logprobs.append(None)
+                    teacher_topk_indices.append(None)
+            else:
+                teacher_topk_logprobs.append(None)
+                teacher_topk_indices.append(None)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Test vLLM serve backend")
+    parser.add_argument("--api-base", type=str, default="http://localhost:8000", help="vLLM serve API base URL")
+    parser.add_argument("--model", type=str, default="default", help="vLLM serve model name")
+    parser.add_argument("--n-logprobs", type=int, default=256, help="Number of logprobs")
+    parser.add_argument("--batch-size", "-b", type=int, default=4, help="Test batch size")
+    parser.add_argument("--seq-len", "-s", type=int, default=128, help="Test sequence length")
+    args = parser.parse_args()
+
+    import random
+
+    # Generate random prompts
+    prompt_token_ids = []
+    for _ in range(args.batch_size):
+        prompt_token_ids.append([random.randint(1, 10000) for _ in range(args.seq_len)])
+
+    backend = VLLMAPIBackend(api_base=args.api_base, n_logprobs=args.n_logprobs,
+                             model=args.model)
+
+    print("Testing get_topk_logprobs...")
+    import time
+
+    start = time.time()
+    responses, logps, indices = backend.get_topk_logprobs(
+        prompt_token_ids, temperature=0.7, max_new_tokens=1, only_response=False
+    )
+    elapsed = time.time() - start
+
+    print(f"Completed in {elapsed:.2f}s")
+    print(f"Responses: {len(responses)}")
+    if logps[0] is not None:
+        print(f"responses shape: {responses[0].shape}")
+        print(f"Logprobs:{logps}")
+        print(f"Logprobs shape: {logps[0].shape}")
+        print(f"indices shape: {indices[0].shape}")

--- a/gkd_ascend/teacher/vllm_api_backend.py
+++ b/gkd_ascend/teacher/vllm_api_backend.py
@@ -26,12 +26,11 @@ Usage:
     python worker.py --backend vllm_serve --api-base http://localhost:8000 --n-logprobs 256
 """
 
-from typing import List, Optional, Union
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import urljoin
 
 import requests
 import torch
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 class VLLMAPIBackend:
@@ -50,12 +49,7 @@ class VLLMAPIBackend:
     """
 
     def __init__(
-      self,
-      api_base: str,
-      n_logprobs: int = 256,
-      timeout: int = 1800,
-      max_retries: int = 3,
-      model: str = "default"
+        self, api_base: str, n_logprobs: int = 256, timeout: int = 1800, max_retries: int = 3, model: str = "default"
     ):
         self.api_base = api_base.rstrip("/")
         self.n_logprobs = n_logprobs
@@ -77,17 +71,17 @@ class VLLMAPIBackend:
                     return
             except requests.exceptions.RequestException as e:
                 if attempt == self.max_retries - 1:
-                    raise RuntimeError(f"Failed to connect to vLLM server at {self.api_base}: {e}")
+                    raise RuntimeError(f"Failed to connect to vLLM server at {self.api_base}: {e}") from e
                 time.sleep(1)
 
         raise RuntimeError(f"vLLM server at {self.api_base} is not healthy")
 
     def _call_completions_api(
-      self,
-      prompt_token_ids: List[List[int]],
-      temperature: float,
-      max_tokens: Union[int, List[int]],
-      only_response: bool,
+        self,
+        prompt_token_ids: list[list[int]],
+        temperature: float,
+        max_tokens: int | list[int],
+        only_response: bool,
     ) -> dict:
         """Call the vLLM completions API with logprobs."""
         url = urljoin(self.api_base, "/v1/completions")
@@ -138,7 +132,7 @@ class VLLMAPIBackend:
                     time.sleep(1)
             except requests.exceptions.RequestException as e:
                 if attempt == self.max_retries - 1:
-                    raise RuntimeError(f"vLLM API request failed: {e}")
+                    raise RuntimeError(f"vLLM API request failed: {e}") from e
                 time.sleep(1)
 
         raise RuntimeError("Failed to get response from vLLM API")
@@ -164,7 +158,6 @@ class VLLMAPIBackend:
         all_indices = []
 
         for token_pos in top_logprobs[1:]:
-
             token_dict = token_pos  # {token_id_str: logprob, ...}
             # Convert to sorted list by logprob (descending)
             items = sorted(token_dict.items(), key=lambda x: x[1], reverse=True)
@@ -194,11 +187,11 @@ class VLLMAPIBackend:
         )
 
     def get_topk_logprobs(
-      self,
-      prompt_token_ids: List[List[int]],
-      temperature: float = 0.8,
-      max_new_tokens: Union[int, List[int]] = 1,
-      only_response: bool = False,
+        self,
+        prompt_token_ids: list[list[int]],
+        temperature: float = 0.8,
+        max_new_tokens: int | list[int] = 1,
+        only_response: bool = False,
     ):
         """
         Get top-k logprobs for given prompts using vLLM serve API.
@@ -228,9 +221,7 @@ class VLLMAPIBackend:
             single_prompt = [prompt_token_ids[idx]]
             single_max_new_tokens = max_new_tokens[idx] if isinstance(max_new_tokens, list) else max_new_tokens
             # Call API
-            api_response = self._call_completions_api(
-                single_prompt, temperature, single_max_new_tokens, only_response
-            )
+            api_response = self._call_completions_api(single_prompt, temperature, single_max_new_tokens, only_response)
             return idx, single_prompt, api_response
 
         results = [None] * batch_size
@@ -244,7 +235,6 @@ class VLLMAPIBackend:
         responses, teacher_topk_logprobs, teacher_topk_indices = [], [], []
 
         for single_prompt, api_response in results:
-
             # Process response
             choices = api_response.get("choices", [])
             choice = choices[0] if choices else {}
@@ -314,8 +304,7 @@ if __name__ == "__main__":
     for _ in range(args.batch_size):
         prompt_token_ids.append([random.randint(1, 10000) for _ in range(args.seq_len)])
 
-    backend = VLLMAPIBackend(api_base=args.api_base, n_logprobs=args.n_logprobs,
-                             model=args.model)
+    backend = VLLMAPIBackend(api_base=args.api_base, n_logprobs=args.n_logprobs, model=args.model)
 
     print("Testing get_topk_logprobs...")
     import time

--- a/gkd_ascend/teacher/vllm_api_backend.py
+++ b/gkd_ascend/teacher/vllm_api_backend.py
@@ -293,6 +293,8 @@ class VLLMAPIBackend:
                 teacher_topk_logprobs.append(None)
                 teacher_topk_indices.append(None)
 
+        return responses, teacher_topk_logprobs, teacher_topk_indices
+
 
 if __name__ == "__main__":
     import argparse

--- a/gkd_ascend/teacher/vllm_engine.py
+++ b/gkd_ascend/teacher/vllm_engine.py
@@ -14,21 +14,20 @@
 
 import argparse
 import random
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import NamedTuple
 
 import torch
 from codetiming import Timer
 from transformers import AutoConfig
-from concurrent.futures import ThreadPoolExecutor, as_completed
-
 from vllm import LLM, SamplingParams
 from vllm.inputs import TokensPrompt
 from vllm.v1.engine.logprobs import LogprobsProcessor
 
 
 def _update_prompt_logprobs(
-  self,
-  prompt_logprobs_tensors,
+    self,
+    prompt_logprobs_tensors,
 ) -> None:
     """Update with prompt logprobs from EngineCore.
 
@@ -117,7 +116,7 @@ class VLLMEngine:
             max_model_len=max_model_len,
             dtype=dtype,
             async_scheduling=True,
-            compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"}
+            compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"},
         )
 
     def get_topk_logprobs(self, prompt_token_ids, temperature=0.8, max_new_tokens=1, only_response=False):
@@ -128,7 +127,7 @@ class VLLMEngine:
                 detokenize=False,
                 logprobs=self.n_logprobs,
                 prompt_logprobs=None if only_response else self.n_logprobs,
-                max_tokens=max_new_token  # max_new_tokens[i] if (i is not None) else max_new_tokens,
+                max_tokens=max_new_token,  # max_new_tokens[i] if (i is not None) else max_new_tokens,
             )
 
         batch_size = len(prompt_token_ids)
@@ -136,11 +135,10 @@ class VLLMEngine:
         def process_single(idx):
             single_prompt = [TokensPrompt(prompt_token_ids=prompt_token_ids[idx])]
             single_sampling_params = [
-                make_sampling_params(max_new_tokens[idx] if isinstance(max_new_tokens, list) else max_new_tokens)]
+                make_sampling_params(max_new_tokens[idx] if isinstance(max_new_tokens, list) else max_new_tokens)
+            ]
             # Call API
-            output = self.llm.generate(
-                single_prompt, sampling_params=single_sampling_params
-            )
+            output = self.llm.generate(single_prompt, sampling_params=single_sampling_params)
             return idx, single_prompt, output
 
         results = [None] * batch_size

--- a/gkd_ascend/teacher/vllm_engine.py
+++ b/gkd_ascend/teacher/vllm_engine.py
@@ -26,8 +26,8 @@ from vllm.v1.engine.logprobs import LogprobsProcessor
 
 
 def _update_prompt_logprobs(
-    self,
-    prompt_logprobs_tensors,
+  self,
+  prompt_logprobs_tensors,
 ) -> None:
     """Update with prompt logprobs from EngineCore.
 
@@ -127,31 +127,22 @@ class VLLMEngine:
                 detokenize=False,
                 logprobs=self.n_logprobs,
                 prompt_logprobs=None if only_response else self.n_logprobs,
-                max_tokens=max_new_token,  # max_new_tokens[i] if (i is not None) else max_new_tokens,
+                max_tokens=max_new_token,
             )
 
-        batch_size = len(prompt_token_ids)
+        prompts = [TokensPrompt(prompt_token_ids=item_prompt_token_ids) for item_prompt_token_ids in prompt_token_ids]
+        if isinstance(max_new_tokens, list):
+            assert len(prompt_token_ids) == len(max_new_tokens)
+        else:
+            max_new_tokens = [max_new_tokens] * len(prompt_token_ids)
 
-        def process_single(idx):
-            single_prompt = [TokensPrompt(prompt_token_ids=prompt_token_ids[idx])]
-            single_sampling_params = [
-                make_sampling_params(max_new_tokens[idx] if isinstance(max_new_tokens, list) else max_new_tokens)
-            ]
-            # Call API
-            output = self.llm.generate(single_prompt, sampling_params=single_sampling_params)
-            return idx, single_prompt, output
+        sampling_params = [make_sampling_params(item_max_new_tokens) for item_max_new_tokens in max_new_tokens]
 
-        results = [None] * batch_size
-
-        with ThreadPoolExecutor(max_workers=batch_size) as executor:
-            futures = {executor.submit(process_single, i): i for i in range(batch_size)}
-            for future in as_completed(futures):
-                idx, single_prompt, output = future.result()
-                results[idx] = (single_prompt, output)
+        results = self.llm.generate(prompts, sampling_params=sampling_params)
 
         responses, teacher_topk_logprobs, teacher_topk_indices = [], [], []
 
-        for single_prompt, output in results:
+        for output in results:
             response_tensor = torch.tensor(output.outputs[0].token_ids, dtype=torch.int32).cpu()
 
             responses.append(response_tensor)

--- a/gkd_ascend/teacher/vllm_engine.py
+++ b/gkd_ascend/teacher/vllm_engine.py
@@ -1,0 +1,216 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import random
+from typing import NamedTuple
+
+import torch
+from codetiming import Timer
+from transformers import AutoConfig
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from vllm import LLM, SamplingParams
+from vllm.inputs import TokensPrompt
+from vllm.v1.engine.logprobs import LogprobsProcessor
+
+
+def _update_prompt_logprobs(
+  self,
+  prompt_logprobs_tensors,
+) -> None:
+    """Update with prompt logprobs from EngineCore.
+
+    Args:
+        prompt_logprobs_tensors: tuple containing the prompt logprobs
+                                tensors.
+
+    """
+
+    # Prompt logprobs are enabled.
+    assert self.num_prompt_logprobs is not None
+    assert self.prompt_logprobs is not None
+
+    self.prompt_logprobs.append(prompt_logprobs_tensors)
+
+
+def _update_sample_logprobs(self, logprobs_lists) -> None:
+    """Update with sample logprobs from EngineCore.
+
+    Outer lists are only of len > 1 if EngineCore made
+    >1 tokens in prior step (e.g. in spec decoding).
+
+    Args:
+        logprobs_lists: the lists of logprob tokens, logprobs, and ranks.
+
+    """
+
+    assert self.num_logprobs is not None
+    assert self.logprobs is not None
+    assert self.cumulative_logprob is not None
+
+    self.logprobs.append(logprobs_lists)
+
+
+LogprobsProcessor._update_prompt_logprobs = _update_prompt_logprobs
+LogprobsProcessor._update_sample_logprobs = _update_sample_logprobs
+
+
+class LogprobsTensors(NamedTuple):
+    # [num_reqs, max_num_logprobs + 1]
+    logprob_token_ids: torch.Tensor
+    # [num_reqs, max_num_logprobs + 1]
+    logprobs: torch.Tensor
+    # [num_reqs]
+    selected_token_ranks: torch.Tensor
+
+    def tolists(self):
+        return LogprobsTensors(
+            logprob_token_ids=self.logprob_token_ids.cpu(),
+            logprobs=self.logprobs.cpu(),
+            selected_token_ranks=self.selected_token_ranks.cpu(),
+        )
+
+    @staticmethod
+    def empty_cpu(num_positions: int, num_tokens_per_position: int) -> "LogprobsTensors":
+        """Create empty LogprobsTensors on CPU."""
+
+        logprob_token_ids = torch.empty((num_positions, num_tokens_per_position), dtype=torch.int32, device="cpu")
+        logprobs = torch.empty_like(logprob_token_ids, dtype=torch.float32)
+        selected_token_ranks = torch.empty(num_positions, dtype=torch.int32, device="cpu")
+        return LogprobsTensors(
+            logprob_token_ids=logprob_token_ids,
+            logprobs=logprobs,
+            selected_token_ranks=selected_token_ranks,
+        )
+
+    def slice(self, start: int, end: int):
+        return LogprobsTensors(
+            self.logprob_token_ids[start:end],
+            self.logprobs[start:end],
+            self.selected_token_ranks[start:end],
+        )
+
+
+class VLLMEngine:
+    def __init__(self, ckpt_path, n_logprobs=0, tp_size=1, max_model_len=8192, dtype="bfloat16"):
+        self.n_logprobs = n_logprobs
+
+        self.llm = LLM(
+            ckpt_path,
+            tensor_parallel_size=tp_size,
+            trust_remote_code=True,
+            enable_chunked_prefill=False,
+            max_logprobs=n_logprobs,
+            gpu_memory_utilization=0.6,
+            max_model_len=max_model_len,
+            dtype=dtype,
+            async_scheduling=True,
+            compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"}
+        )
+
+    def get_topk_logprobs(self, prompt_token_ids, temperature=0.8, max_new_tokens=1, only_response=False):
+        def make_sampling_params(max_new_token):
+            return SamplingParams(
+                temperature=temperature,
+                top_p=0.95,
+                detokenize=False,
+                logprobs=self.n_logprobs,
+                prompt_logprobs=None if only_response else self.n_logprobs,
+                max_tokens=max_new_token  # max_new_tokens[i] if (i is not None) else max_new_tokens,
+            )
+
+        batch_size = len(prompt_token_ids)
+
+        def process_single(idx):
+            single_prompt = [TokensPrompt(prompt_token_ids=prompt_token_ids[idx])]
+            single_sampling_params = [
+                make_sampling_params(max_new_tokens[idx] if isinstance(max_new_tokens, list) else max_new_tokens)]
+            # Call API
+            output = self.llm.generate(
+                single_prompt, sampling_params=single_sampling_params
+            )
+            return idx, single_prompt, output
+
+        results = [None] * batch_size
+
+        with ThreadPoolExecutor(max_workers=batch_size) as executor:
+            futures = {executor.submit(process_single, i): i for i in range(batch_size)}
+            for future in as_completed(futures):
+                idx, single_prompt, output = future.result()
+                results[idx] = (single_prompt, output)
+
+        responses, teacher_topk_logprobs, teacher_topk_indices = [], [], []
+
+        for single_prompt, output in results:
+            response_tensor = torch.tensor(output.outputs[0].token_ids, dtype=torch.int32).cpu()
+
+            responses.append(response_tensor)
+
+            if self.n_logprobs > 0:
+                response_topk_logprobs = torch.tensor(
+                    [x.logprobs[0] for x in output.outputs[0].logprobs],
+                    dtype=torch.float32,
+                )[:, 1:]
+                response_topk_indices = torch.tensor(
+                    [x.logprob_token_ids[0] for x in output.outputs[0].logprobs],
+                    dtype=torch.int32,
+                )[:, 1:]
+                if only_response:
+                    teacher_topk_logprobs.append(response_topk_logprobs.cpu())
+                    teacher_topk_indices.append(response_topk_indices.cpu())
+                else:
+                    prompt_topk_logprobs = output.prompt_logprobs[1].logprobs[:, 1:].to(torch.float32)
+                    prompt_topk_indices = output.prompt_logprobs[1].logprob_token_ids[:, 1:].to(torch.int32)
+                    teacher_topk_logprobs.append(torch.vstack([prompt_topk_logprobs, response_topk_logprobs]).cpu())
+                    teacher_topk_indices.append(torch.vstack([prompt_topk_indices, response_topk_indices]).cpu())
+
+            torch.npu.empty_cache()
+
+        return responses, teacher_topk_logprobs, teacher_topk_indices
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test vLLM logprob")
+    parser.add_argument("model_dir", help="Model directory")
+    parser.add_argument("--tp-size", type=int, default=1, help="TP size")
+    parser.add_argument("--batch-size", "-b", type=int, default=64, help="Test batch size")
+    parser.add_argument("--seq-len", "-s", type=int, default=3840, help="Test sequence length")
+    args = parser.parse_args()
+
+    config = AutoConfig.from_pretrained(args.model_dir)
+    print(f"Reading configs from {args.model_dir}: {config.vocab_size=}")
+
+    prompt_token_ids = []
+    if args.token_file:
+        # Init input with tokenid file
+        from get_batch import get_batch
+
+        prompt_token_ids = get_batch()
+    else:
+        # Init input randomly
+        prompt_lens = args.batch_size * [args.seq_len]
+        for pl in prompt_lens:
+            prompt_token_ids.append([random.randint(1, config.vocab_size - 1000) for j in range(pl)])
+
+    engine = VLLMEngine(ckpt_path=args.model_dir, n_logprobs=256, tp_size=args.tp_size)
+
+    with Timer(name="get_topk_logprobs", initial_text=True):
+        responses, teacher_topk_logprobs, teacher_topk_indices = engine.get_topk_logprobs(
+            prompt_token_ids, temperature=0.7, max_new_tokens=1, only_response=True
+        )
+    # debug
+    import ipdb
+
+    ipdb.set_trace()

--- a/gkd_ascend/teacher/vllm_engine.py
+++ b/gkd_ascend/teacher/vllm_engine.py
@@ -14,7 +14,6 @@
 
 import argparse
 import random
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import NamedTuple
 
 import torch
@@ -26,8 +25,8 @@ from vllm.v1.engine.logprobs import LogprobsProcessor
 
 
 def _update_prompt_logprobs(
-  self,
-  prompt_logprobs_tensors,
+    self,
+    prompt_logprobs_tensors,
 ) -> None:
     """Update with prompt logprobs from EngineCore.
 

--- a/gkd_ascend/teacher/worker.py
+++ b/gkd_ascend/teacher/worker.py
@@ -1,0 +1,118 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import functools
+
+import torch
+import zmq
+from codetiming import Timer
+from utils import deserialize, serialize
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--proxy-addr", type=str, default="localhost:15556")
+    parser.add_argument("--backend", type=str, default="vllm")
+    parser.add_argument("--n-logprobs", type=int, default=256)
+    parser.add_argument("--tp-size", type=int, default=1)
+    parser.add_argument("--ckpt-path", type=str)
+    parser.add_argument("--max-model-len", type=int, default=8192)
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument("--api-base", type=str, default="http://localhost:8000",
+                        help="vLLM serve API base URL (for vllm api backend)")
+    parser.add_argument("--serve-model", type=str, default="default",
+                        help="Model name for vLLM serve API requests (for vllm api backend)")
+    parser.add_argument("--timeout", type=int, default=600)
+
+    args = parser.parse_args()
+    print('worker args:', args)
+
+    if args.backend == "vllm_engine":
+        from vllm_engine import VLLMEngine
+
+        engine = VLLMEngine(
+            ckpt_path=args.ckpt_path,
+            n_logprobs=args.n_logprobs,
+            tp_size=args.tp_size,
+            max_model_len=args.max_model_len,
+            dtype=args.dtype
+        )
+
+    elif args.backend == "vllm_api":
+        from vllm_api_backend import VLLMAPIBackend
+
+        engine = VLLMAPIBackend(
+            api_base=args.api_base,
+            n_logprobs=args.n_logprobs,
+            timeout=args.timeout,
+            model=args.serve_model,
+        )
+
+    else:
+        raise ValueError(f"Unknown backend: {args.backend}.")
+
+    context = zmq.Context()
+    socket = context.socket(zmq.REP)
+    # socket.bind(f"tcp://*:{port}")
+    socket.connect(f"tcp://{args.proxy_addr}")
+
+    print("worker started...", flush=True)
+
+    # TODO: 新增prefix_cache_hit监控
+
+    while True:
+        message = socket.recv()
+        try:
+            with Timer(name="deserialize", initial_text=True, logger=functools.partial(print, flush=True)):
+                request = deserialize(message)
+        except Exception as e:
+            print("[Server Error] Deserialize failed:", str(e), flush=True)
+            socket.send(serialize({"status": "error", "reason": f"Deserialize failed: {e}"}))
+            continue
+        if isinstance(request, dict) and "prompt_token_ids" in request:
+            prompt_token_ids = request["prompt_token_ids"]
+            temperature = request.get("temperature", 0.8)
+            max_tokens = request.get("max_tokens", 1)
+            only_response = request.get("only_response", False)
+            if isinstance(prompt_token_ids, torch.Tensor):
+                prompt_token_ids = prompt_token_ids.tolist()
+            with Timer(name="get_prompt_topk_logprobs", initial_text=True, logger=functools.partial(print, flush=True)):
+                ### try and sendback error
+                try:
+                    responses, logps, indices = engine.get_topk_logprobs(
+                        prompt_token_ids, temperature, max_new_tokens=max_tokens, only_response=only_response
+                    )
+                except Exception as e:
+                    print("[Server Error] Exception occurred during generation:", str(e))
+                    socket.send(serialize({"status": "error", "reason": f"Generate failed: {str(e)}"}))
+                    continue
+            with Timer(name="serialize", initial_text=True, logger=functools.partial(print, flush=True)):
+                message = serialize(
+                    {
+                        "status": "ok",
+                        "teacher_topk_logprobs": logps,
+                        "teacher_topk_indices": indices,
+                        "responses": responses,
+                    }
+                )
+            with Timer(name="send", initial_text=True, logger=functools.partial(print, flush=True)):
+                socket.send(message)
+
+        else:
+            socket.send(serialize({"status": "error", "reason": "invalid request format."}))
+
+
+if __name__ == "__main__":
+    main()

--- a/gkd_ascend/teacher/worker.py
+++ b/gkd_ascend/teacher/worker.py
@@ -30,14 +30,19 @@ def main():
     parser.add_argument("--ckpt-path", type=str)
     parser.add_argument("--max-model-len", type=int, default=8192)
     parser.add_argument("--dtype", type=str, default="bfloat16")
-    parser.add_argument("--api-base", type=str, default="http://localhost:8000",
-                        help="vLLM serve API base URL (for vllm api backend)")
-    parser.add_argument("--serve-model", type=str, default="default",
-                        help="Model name for vLLM serve API requests (for vllm api backend)")
+    parser.add_argument(
+        "--api-base", type=str, default="http://localhost:8000", help="vLLM serve API base URL (for vllm api backend)"
+    )
+    parser.add_argument(
+        "--serve-model",
+        type=str,
+        default="default",
+        help="Model name for vLLM serve API requests (for vllm api backend)",
+    )
     parser.add_argument("--timeout", type=int, default=600)
 
     args = parser.parse_args()
-    print('worker args:', args)
+    print("worker args:", args)
 
     if args.backend == "vllm_engine":
         from vllm_engine import VLLMEngine
@@ -47,7 +52,7 @@ def main():
             n_logprobs=args.n_logprobs,
             tp_size=args.tp_size,
             max_model_len=args.max_model_len,
-            dtype=args.dtype
+            dtype=args.dtype,
         )
 
     elif args.backend == "vllm_api":

--- a/gkd_ascend/teacher_utils.py
+++ b/gkd_ascend/teacher_utils.py
@@ -69,7 +69,7 @@ def get_teacher_knowledge(batch: DataProto, teacher_client, n_server_workers=1, 
         tok1 = max(tok1, time.time())
 
     for i in range(0, batch_size, micro_batch_size):
-        fut = teacher_client.submit(input_ids[i: i + micro_batch_size])
+        fut = teacher_client.submit(input_ids[i : i + micro_batch_size])
         fut.add_done_callback(cb)
         futures.append(fut)
 
@@ -98,18 +98,18 @@ def get_teacher_knowledge(batch: DataProto, teacher_client, n_server_workers=1, 
 
         global teacher_topk_logps_padded, teacher_topk_indices_padded
         if (
-          teacher_topk_logps_padded is None
-          or teacher_topk_logps_padded.dtype != logp_dtype
-          or teacher_topk_logps_padded.shape != torch.Size(teacher_knowledge_shape)
+            teacher_topk_logps_padded is None
+            or teacher_topk_logps_padded.dtype != logp_dtype
+            or teacher_topk_logps_padded.shape != torch.Size(teacher_knowledge_shape)
         ):
             teacher_topk_logps_padded = torch.zeros(*teacher_knowledge_shape, dtype=logp_dtype)
         else:
             teacher_topk_logps_padded.zero_()
 
         if (
-          teacher_topk_indices_padded is None
-          or teacher_topk_indices_padded.dtype != idx_dtype
-          or teacher_topk_indices_padded.shape != torch.Size(teacher_knowledge_shape)
+            teacher_topk_indices_padded is None
+            or teacher_topk_indices_padded.dtype != idx_dtype
+            or teacher_topk_indices_padded.shape != torch.Size(teacher_knowledge_shape)
         ):
             teacher_topk_indices_padded = torch.zeros(*teacher_knowledge_shape, dtype=idx_dtype)
         else:

--- a/gkd_ascend/teacher_utils.py
+++ b/gkd_ascend/teacher_utils.py
@@ -1,0 +1,172 @@
+# Copyright 2025 Individual Contributor: furunding
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utility functions for teacher model knowledge distillation.
+
+Functions:
+    get_teacher_knowledge: Retrieve teacher model's top-k predictions and log probabilities.
+"""
+
+import time
+from types import SimpleNamespace
+
+import torch
+
+from verl import DataProto
+
+teacher_topk_logps_padded, teacher_topk_indices_padded = None, None
+
+
+def get_teacher_knowledge(batch: DataProto, teacher_client, n_server_workers=1, is_async=False):
+    """
+    Retrieve teacher model's top-k predictions and log probabilities for knowledge distillation.
+
+    Args:
+        batch (DataProto): Input batch containing input_ids and attention_mask
+        teacher_client: Client for communicating with teacher model
+        n_server_workers (int): Number of parallel workers for teacher model inference
+        is_async (bool): Whether to use asynchronous processing
+
+    Returns:
+        If is_async=True: SimpleNamespace with get() method to process futures
+        If is_async=False: Processed DataProto containing teacher knowledge
+
+    Raises:
+        RuntimeError: If teacher model request fails
+    """
+
+    input_ids = []
+    attention_mask = batch.batch["attention_mask"].to(torch.bool)
+    # response_length = batch.meta_info["response_length"]
+
+    for ids, mask in zip(batch.batch["input_ids"], attention_mask, strict=False):
+        input_ids.append(ids[mask].tolist())
+
+    all_teacher_topk_logps = []
+    all_teacher_topk_indices = []
+
+    batch_size = len(input_ids)
+    assert batch_size % n_server_workers == 0
+    micro_batch_size = batch_size // n_server_workers
+    futures = []
+    tik1 = time.time()
+    tok1 = tik1
+
+    def cb(future):
+        nonlocal tok1
+        tok1 = max(tok1, time.time())
+
+    for i in range(0, batch_size, micro_batch_size):
+        fut = teacher_client.submit(input_ids[i: i + micro_batch_size])
+        fut.add_done_callback(cb)
+        futures.append(fut)
+
+    def handle_futures():
+        for future in futures:
+            try:
+                _, teacher_topk_logps, teacher_topk_indices = future.result()
+            except Exception as e:
+                raise RuntimeError(f"Teacher request failed: {e}") from e
+
+            all_teacher_topk_logps.extend(teacher_topk_logps)
+            all_teacher_topk_indices.extend(teacher_topk_indices)
+
+        tik2 = time.time()
+        # teacher_topk_logps = [x.to(params_dtype) for x in all_teacher_topk_logps]
+        # teacher_topk_indices = [x.to(params_dtype) for x in all_teacher_topk_indices]
+        teacher_topk_logps, teacher_topk_indices = all_teacher_topk_logps, all_teacher_topk_indices
+
+        real_seq_lens = torch.tensor([x.size(0) for x in teacher_topk_logps], dtype=torch.int32)
+
+        topk = teacher_topk_logps[0].size(-1)
+
+        logp_dtype = teacher_topk_logps[0].dtype
+        idx_dtype = teacher_topk_indices[0].dtype
+        teacher_knowledge_shape = list(batch.batch["input_ids"].shape) + [topk]
+
+        global teacher_topk_logps_padded, teacher_topk_indices_padded
+        if (
+          teacher_topk_logps_padded is None
+          or teacher_topk_logps_padded.dtype != logp_dtype
+          or teacher_topk_logps_padded.shape != torch.Size(teacher_knowledge_shape)
+        ):
+            teacher_topk_logps_padded = torch.zeros(*teacher_knowledge_shape, dtype=logp_dtype)
+        else:
+            teacher_topk_logps_padded.zero_()
+
+        if (
+          teacher_topk_indices_padded is None
+          or teacher_topk_indices_padded.dtype != idx_dtype
+          or teacher_topk_indices_padded.shape != torch.Size(teacher_knowledge_shape)
+        ):
+            teacher_topk_indices_padded = torch.zeros(*teacher_knowledge_shape, dtype=idx_dtype)
+        else:
+            teacher_topk_indices_padded.zero_()
+
+        batch_size = attention_mask.size(0)
+        for i in range(batch_size):
+            teacher_topk_logps_padded[i][attention_mask[i]] = teacher_topk_logps[i]
+            teacher_topk_indices_padded[i][attention_mask[i]] = teacher_topk_indices[i]
+
+        output_batch = DataProto.from_single_dict(
+            data={"real_seq_lens": real_seq_lens},
+        )
+
+        output_batch.non_tensor_batch.update(
+            {
+                "teacher_topk_logps": teacher_topk_logps_padded.numpy(),
+                "teacher_topk_indices": teacher_topk_indices_padded.numpy(),
+            }
+        )
+
+        tok2 = time.time()
+
+        output_batch.meta_info["timing"] = {"get_teacher_knowledge": (tok1 - tik1) + (tok2 - tik2)}
+
+        return output_batch
+
+    if is_async:
+        return SimpleNamespace(get=handle_futures)
+    else:
+        return handle_futures()
+
+
+if __name__ == "__main__":
+    batch = DataProto.load_from_disk("gen_batch_output")
+    from teacher import TeacherClient
+
+    teacher_client = TeacherClient(server_ip="10.215.192.141", server_port=15555)
+    output_batch = get_teacher_knowledge(batch, 2, teacher_client)
+    output_batch_chunks = output_batch.chunk(2)
+
+    for data in output_batch_chunks:
+        topk = data.meta_info["topk"]
+        seq_lens = data.batch["seq_lens"]
+        teacher_topk_logps = data.batch["teacher_topk_logps"].view(-1, topk)
+        teacher_topk_indices = data.batch["teacher_topk_indices"].view(-1, topk)
+
+        attention_mask = data.batch["attention_mask"]
+        batch_size, sequence_length = attention_mask.size(0), attention_mask.size(1)
+        teacher_topk_logps_padded = torch.zeros(batch_size, sequence_length, topk, dtype=teacher_topk_logps.dtype)
+        teacher_topk_indices_padded = torch.zeros(batch_size, sequence_length, topk, dtype=teacher_topk_indices.dtype)
+
+        teacher_topk_logps_padded[attention_mask] = teacher_topk_logps[: seq_lens.sum()]
+        teacher_topk_indices_padded[attention_mask] = teacher_topk_indices[: seq_lens.sum()]
+
+        data.batch["teacher_topk_logps"] = teacher_topk_logps_padded
+        data.batch["teacher_topk_indices"] = teacher_topk_indices_padded
+
+        assert (data.batch["teacher_topk_logps"] == data.batch["teacher_topk_logps_padded"]).all()
+        assert (data.batch["teacher_topk_indices"] == data.batch["teacher_topk_indices_padded"]).all()


### PR DESCRIPTION
## Summary

This PR adds a new recipe `gkd_ascend` that extends the original GKD (On-Policy Knowledge Distillation) recipe with:

- **Ascend NPU support**: HCCL communication backend, device auto-detection, NPU-aware weight sync group creation
- **FSDP/FSDP2 backend**: Alternative training backend alongside Megatron for users who prefer FSDP's simpler deployment model
- **Teacher vLLM API backend**: Connects to an existing vLLM serve API server via OpenAI-compatible completions API, useful when teacher model is deployed as a standalone inference service

## Key Changes

| Component | Description |
|-----------|-------------|
| `main_gkd.py` | Entry point with device auto-detection and backend selection |
| `ray_trainer.py` | NPU-aware weight-sync group creation using HCCL |
| `distributed_util.py` | HCCL backend selection for NPU |
| `fsdp_workers.py` | FSDP actor/rollout workers for KD |
| `fsdp_kl_loss.py` | KL loss for FSDP (full vocab, no TP sharding) |
| `megatron_workers.py` | Megatron workers with NPU adaptations |
| `teacher/vllm_api_backend.py` | Remote vLLM serve API backend |
| `run_4b_fsdp.sh` / `run_4b_megatron.sh` | Example launch scripts |
