### PR TITLE
feat(retool): add RL training script for Qwen3.5 on NPU (Ascend).

### DIFF
--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -97,7 +97,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.multi_turn.enable=True \
     actor_rollout_ref.rollout.multi_turn.max_user_turns=$max_turns \
     actor_rollout_ref.rollout.multi_turn.max_assistant_turns=$max_turns \
-    actor_rollout_ref.rollout.multi_turn.tool_config_path=$tool_config_path \
+    actor_rollout_ref.rollout.multi_turn.tool_config_path="$tool_config_path" \
     actor_rollout_ref.rollout.multi_turn.format=hermes \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
     actor_rollout_ref.rollout.n=$n_resp_per_prompt \

--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -121,6 +121,6 @@ python3 -m verl.trainer.main_ppo \
     trainer.nnodes=1 \
     trainer.device=npu \
     trainer.save_freq=20 \
-    trainer.default_local_dir=$default_local_dir \
+    trainer.default_local_dir="$default_local_dir" \
     trainer.test_freq=10 \
     trainer.total_epochs=1 $@

--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -1,4 +1,4 @@
-set -x
+set -xe
 
 # echo "127.0.0.1 localhost" >> /etc/hosts # Add localhost for container environments if needed
 export VLLM_USE_V1=1

--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -22,7 +22,7 @@ train_files="['$dapo_math_17k']"
 test_files="['$aime_2024']"
 
 # tool
-tool_config_path=verl-recipe/retool/sandbox_fusion_tool_config.yaml
+tool_config_path="$SCRIPT_DIR/sandbox_fusion_tool_config.yaml"
 
 # wandb
 project_name=retool

--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -1,0 +1,125 @@
+set -x
+
+# echo "127.0.0.1 localhost" >> /etc/hosts # Add localhost for container environments if needed
+export VLLM_USE_V1=1
+export TORCHDYNAMO_DISABLE=1
+export VLLM_ASCEND_ENABLE_NZ=0
+export TASK_QUEUE_ENABLE=1
+export VLLM_ENABLE_GRAPH_MODE=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+# export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 # Specify NPU_IDs if needed
+
+# ================= data/model/tool =================
+HDFS_ROOT=${HDFS_ROOT:-$PWD}
+DATA_ROOT=${DATA_ROOT:-$PWD}
+
+dapo_math_17k=$DATA_ROOT/dataset/BytedTsinghua-SIA/DAPO-Math-17k
+aime_2024=$DATA_ROOT/dataset/Maxwell-Jia/AIME_2024
+model_path=$HDFS_ROOT/checkpoint/multiturn-sft-qwen-3.5-9b/global_step_372/huggingface
+
+train_files="['$dapo_math_17k']"
+test_files="['$aime_2024']"
+
+# tool
+tool_config_path=verl-recipe/retool/sandbox_fusion_tool_config.yaml
+
+# wandb
+project_name=retool
+experiment_name=qwen3.5-9b_dapo_npu
+default_local_dir=$DATA_ROOT/ckpts/$experiment_name
+
+# ================= algorithm =================
+adv_estimator=grpo
+
+use_kl_in_reward=False
+kl_coef=0.0
+use_kl_loss=False
+kl_loss_coef=0.0
+
+clip_ratio_low=0.2
+clip_ratio_high=0.28
+
+max_turns=16
+max_prompt_length=2048
+max_response_length=16384
+actor_lr=1e-6
+
+train_batch_size=32
+ppo_mini_batch_size=16
+n_resp_per_prompt=16
+n_resp_per_prompt_val=16
+
+# ================= perfomance =================
+infer_tp=4 # vllm
+train_sp=4 # train
+offload=True
+
+actor_max_token_len_per_gpu=$(( (max_prompt_length + max_response_length) * 1 ))
+log_prob_max_token_len_per_gpu=$(( actor_max_token_len_per_gpu * 4 ))
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=$adv_estimator \
+    algorithm.use_kl_in_reward=$use_kl_in_reward \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.return_raw_chat=True \
+    data.train_batch_size=$train_batch_size \
+    data.max_prompt_length=$max_prompt_length \
+    data.max_response_length=$max_response_length \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    data.custom_cls.path=verl-recipe/retool/retool.py \
+    data.custom_cls.name=CustomRLHFDataset \
+    custom_reward_function.path=verl-recipe/retool/retool.py \
+    custom_reward_function.name=compute_score \
+    actor_rollout_ref.model.path=$model_path \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_kl_loss=$use_kl_loss \
+    actor_rollout_ref.actor.kl_loss_coef=$kl_loss_coef \
+    actor_rollout_ref.actor.clip_ratio_low=$clip_ratio_low \
+    actor_rollout_ref.actor.clip_ratio_high=$clip_ratio_high \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.actor.optim.lr=$actor_lr \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$ppo_mini_batch_size \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$actor_max_token_len_per_gpu \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=$train_sp \
+    actor_rollout_ref.actor.fsdp_config.param_offload=$offload \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=$offload \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=$log_prob_max_token_len_per_gpu \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.max_num_seqs=256 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$infer_tp \
+    actor_rollout_ref.rollout.multi_turn.enable=True \
+    actor_rollout_ref.rollout.multi_turn.max_user_turns=$max_turns \
+    actor_rollout_ref.rollout.multi_turn.max_assistant_turns=$max_turns \
+    actor_rollout_ref.rollout.multi_turn.tool_config_path=$tool_config_path \
+    actor_rollout_ref.rollout.multi_turn.format=hermes \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=$n_resp_per_prompt \
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.6 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=1.0 \
+    actor_rollout_ref.rollout.val_kwargs.n=$n_resp_per_prompt_val \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.actor.entropy_checkpointing=True \
+    actor_rollout_ref.ref.entropy_checkpointing=True \
+    actor_rollout_ref.actor.entropy_from_logits_with_chunking=True \
+    actor_rollout_ref.ref.entropy_from_logits_with_chunking=True \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.ref.use_torch_compile=False \
+    trainer.logger=['console'] \
+    trainer.project_name=$project_name \
+    trainer.experiment_name=$experiment_name \
+    trainer.n_gpus_per_node=8 \
+    trainer.val_before_train=False \
+    trainer.log_val_generations=20 \
+    trainer.nnodes=1 \
+    trainer.device=npu \
+    trainer.save_freq=20 \
+    trainer.default_local_dir=$default_local_dir \
+    trainer.test_freq=10 \
+    trainer.total_epochs=1 $@

--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -70,9 +70,9 @@ python3 -m verl.trainer.main_ppo \
     data.max_response_length=$max_response_length \
     data.filter_overlong_prompts=True \
     data.truncation='error' \
-    data.custom_cls.path=verl-recipe/retool/retool.py \
+    data.custom_cls.path="$SCRIPT_DIR/retool.py" \
     data.custom_cls.name=CustomRLHFDataset \
-    custom_reward_function.path=verl-recipe/retool/retool.py \
+    custom_reward_function.path="$SCRIPT_DIR/retool.py" \
     custom_reward_function.name=compute_score \
     actor_rollout_ref.model.path=$model_path \
     actor_rollout_ref.model.use_remove_padding=True \

--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -10,6 +10,7 @@ export HCCL_OP_EXPANSION_MODE="AIV"
 # export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 # Specify NPU_IDs if needed
 
 # ================= data/model/tool =================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HDFS_ROOT=${HDFS_ROOT:-$PWD}
 DATA_ROOT=${DATA_ROOT:-$PWD}
 

--- a/retool/run_qwen35-9b_dapo_npu.sh
+++ b/retool/run_qwen35-9b_dapo_npu.sh
@@ -74,7 +74,7 @@ python3 -m verl.trainer.main_ppo \
     data.custom_cls.name=CustomRLHFDataset \
     custom_reward_function.path="$SCRIPT_DIR/retool.py" \
     custom_reward_function.name=compute_score \
-    actor_rollout_ref.model.path=$model_path \
+    actor_rollout_ref.model.path="$model_path" \
     actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.use_kl_loss=$use_kl_loss \


### PR DESCRIPTION
## Summary
An example script and usage for ReTool DAPO RL training of the Qwen3.5 model on NPU (Ascend).

## Usage
### Environment Requirements
Ensure the environment meets the requirements for Qwen3.5 inference and reinforcement learning (RL) training.

**Reference versions:**
- `verl` : 0.8.0.dev0
- `vllm` : 0.18.0+empty
- `vllm_ascend` : 0.17.0rc2.dev109+g54879467c
- `transformers` : 5.3.0.dev0
- `torch` : 2.9.0+cpu
- `torch_npu` : 2.9.0
- `ray` : 2.48.0

**Reference official Docker image:**
`quay.io/ascend/verl:verl-8.5.2-910b-ubuntu22.04-py3.11-qwen3-5`

### Clone verl-recipe
```bash
git clone https://github.com/verl-project/verl-recipe.git
```

### Deploy Required Tools
For example, to set up Sandbox, refer to: `https://github.com/bytedance/SandboxFusion.git`

### Data Preparation

#### Preprocess SFT dataset (confirm or modify the save path)
```bash
python3 verl-recipe/retool/retool_sft_preprocess.py
```

#### Download RL and Val datasets (e.g. DAPO-Math-17k, AIME_2024)
```bash
hf download BytedTsinghua-SIA/DAPO-Math-17k --local-dir ./dataset/BytedTsinghua-SIA/DAPO-Math-17k --repo-type dataset
hf download Maxwell-Jia/AIME_2024 --local-dir ./dataset/Maxwell-Jia/AIME_2024 --repo-type dataset
```

### Training
#### SFT
```bash
bash verl-recipe/retool/run_qwen35-9b_sft_npu.sh
```

#### Convert weights
```bash
python3 -m verl.model_merger merge --backend fsdp --local_dir /checkpoint/multiturn-sft-qwen-3.5-9b/global_step_372 --target_dir /checkpoint/multiturn-sft-qwen-3.5-9b/global_step_372/huggingface
```

#### RL
```bash
bash verl-recipe/retool/run_qwen35-9b_dapo_npu.sh
```