### PR TITLE
[rollout] fix: remove legacy rolloutskip

### DIFF
--- a/dance_grpo/dance_grpo_fsdp/config/dance_ppo_trainer.yaml
+++ b/dance_grpo/dance_grpo_fsdp/config/dance_ppo_trainer.yaml
@@ -257,8 +257,6 @@ actor_rollout_ref:
       backend: null
       token2text: false
       max_samples_per_step_per_worker: null
-    skip_rollout: false
-    skip_dump_dir: /tmp/rollout_dump
     skip_tokenizer_init: true
     enable_rollout_routing_replay: false
     profiler:

--- a/dance_grpo/dance_grpo_mindspeed_mm/config/dance_ppo_trainer.yaml
+++ b/dance_grpo/dance_grpo_mindspeed_mm/config/dance_ppo_trainer.yaml
@@ -257,8 +257,6 @@ actor_rollout_ref:
       backend: null
       token2text: false
       max_samples_per_step_per_worker: null
-    skip_rollout: false
-    skip_dump_dir: /tmp/rollout_dump
     skip_tokenizer_init: true
     enable_rollout_routing_replay: false
     profiler:

--- a/dance_grpo/dance_grpo_mindspeed_mm/dance_ray_trainer.py
+++ b/dance_grpo/dance_grpo_mindspeed_mm/dance_ray_trainer.py
@@ -40,7 +40,6 @@ from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
-from verl.utils.rollout_skip import RolloutSkip
 from verl.utils.tracking import ValidationGenerationsLogger
 
 
@@ -439,10 +438,6 @@ class RayDANCETrainer(RayPPOTrainer):
             logger.log(data=val_metrics, step=self.global_steps)
             if self.config.trainer.get("val_only", False):
                 return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
-            rollout_skip.wrap_generate_sequences()
 
         # add tqdm
         progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")

--- a/dapo/dapo_ray_trainer.py
+++ b/dapo/dapo_ray_trainer.py
@@ -40,7 +40,6 @@ from verl.trainer.ppo.reward import extract_reward
 from verl.utils.checkpoint.checkpoint_manager import should_save_ckpt_esi
 from verl.utils.metric import reduce_metrics
 from verl.utils.profiler import marked_timer
-from verl.utils.rollout_skip import RolloutSkip
 
 
 class RayDAPOTrainer(RayPPOTrainer):
@@ -114,10 +113,6 @@ class RayDAPOTrainer(RayPPOTrainer):
             logger.log(data=val_metrics, step=self.global_steps)
             if self.config.trainer.get("val_only", False):
                 return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.async_rollout_manager)
-            rollout_skip.wrap_generate_sequences()
 
         # add tqdm
         progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")

--- a/dapo/dapo_transfer_queue/dapo_ray_trainer.py
+++ b/dapo/dapo_transfer_queue/dapo_ray_trainer.py
@@ -44,7 +44,6 @@ from verl import DataProto
 from verl.trainer.ppo.core_algos import agg_loss
 from verl.utils.metric import reduce_metrics
 from verl.utils.profiler import marked_timer
-from verl.utils.rollout_skip import RolloutSkip
 from verl.utils.seqlen_balancing import (
     calculate_workload,
     get_seqlen_balanced_partitions,
@@ -133,10 +132,6 @@ class RayDAPOTrainer(RayPPOTrainer):
             logger.log(data=val_metrics, step=self.global_steps)
             if self.config.trainer.get("val_only", False):
                 return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
-            rollout_skip.wrap_generate_sequences()
 
         progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")
         self.global_steps += 1

--- a/partial_rollout/ray_trainer.py
+++ b/partial_rollout/ray_trainer.py
@@ -30,7 +30,6 @@ from verl.trainer.ppo.core_algos import AdvantageEstimator
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer, compute_response_mask
 from verl.trainer.ppo.utils import Role, WorkerType
 from verl.utils.debug import marked_timer
-from verl.utils.rollout_skip import RolloutSkip
 
 
 class PartialRolloutRayPPOTrainer(SeparateRayPPOTrainer):
@@ -262,10 +261,6 @@ class PartialRolloutRayPPOTrainer(SeparateRayPPOTrainer):
             self.logger.log(data=val_metrics, step=self.global_steps)
             if self.config.trainer.get("val_only", False):
                 return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
-            rollout_skip.wrap_generate_sequences()
 
         # add tqdm
         self.progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")

--- a/rep_exp/config/_generated_ppo_megatron_trainer.yaml
+++ b/rep_exp/config/_generated_ppo_megatron_trainer.yaml
@@ -252,8 +252,6 @@ actor_rollout_ref:
       backend: null
       token2text: false
       max_samples_per_step_per_worker: null
-    skip_rollout: false
-    skip_dump_dir: /tmp/rollout_dump
     skip_tokenizer_init: true
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig

--- a/rep_exp/config/_generated_ppo_trainer.yaml
+++ b/rep_exp/config/_generated_ppo_trainer.yaml
@@ -240,8 +240,6 @@ actor_rollout_ref:
       backend: null
       token2text: false
       max_samples_per_step_per_worker: null
-    skip_rollout: false
-    skip_dump_dir: /tmp/rollout_dump
     skip_tokenizer_init: true
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig

--- a/rep_exp/config/rollout/rollout.yaml
+++ b/rep_exp/config/rollout/rollout.yaml
@@ -264,15 +264,6 @@ trace:
   # Total traces per step = max_samples_per_step_per_worker * num_workers * n_rollouts_per_sample
   max_samples_per_step_per_worker: null
 
-# When enabled (True), the trainer will attempt to load previously generated rollout data from the specified directory instead of computing new rollouts.
-# If no cached data is found or loading fails, new rollouts will be generated and automatically saved.
-# This feature is useful for debugging or when you want to reuse computation results across multiple runs.
-skip_rollout: False
-
-# Specifies the filesystem path where rollout data should be cached when skip_rollout is enabled.
-# Note: Giving path under /tmp/ray/session* is not recommended as these are temporary Ray cluster directories.
-skip_dump_dir: /tmp/rollout_dump
-
 # Whether to skip tokenizer initialization for rollout engine
 # When enabled (True), the rollout assume token in token out for generation
 skip_tokenizer_init: True

--- a/rep_exp/rep_exp_trainer.py
+++ b/rep_exp/rep_exp_trainer.py
@@ -48,7 +48,6 @@ from verl.utils.checkpoint.checkpoint_manager import should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.utils.metric import reduce_metrics
-from verl.utils.rollout_skip import RolloutSkip
 
 from .metric_utils import compute_data_metrics, process_validation_metrics
 
@@ -389,10 +388,6 @@ class RayRepExpTrainer(RayPPOTrainer):
 
             if self.config.trainer.get("val_only", False):
                 return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
-            rollout_skip.wrap_generate_sequences()
 
         # add tqdm
         progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")

--- a/specRL/histoSpec/ray_trainer.py
+++ b/specRL/histoSpec/ray_trainer.py
@@ -57,7 +57,6 @@ from verl.utils.checkpoint.checkpoint_manager import should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.utils.metric import reduce_metrics
-from verl.utils.rollout_skip import RolloutSkip
 
 
 class SpecRLRayPPOTrainer(RayPPOTrainer):
@@ -412,10 +411,6 @@ class SpecRLRayPPOTrainer(RayPPOTrainer):
             logger.log(data=val_metrics, step=self.global_steps)
             if self.config.trainer.get("val_only", False):
                 return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
-            rollout_skip.wrap_generate_sequences()
 
         # add tqdm
         progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")

--- a/spo/spo_ray_trainer.py
+++ b/spo/spo_ray_trainer.py
@@ -56,7 +56,6 @@ from verl.utils.checkpoint.checkpoint_manager import should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.utils.metric import reduce_metrics
-from verl.utils.rollout_skip import RolloutSkip
 from verl.utils.torch_functional import masked_mean
 
 # Re-export for backward compatibility
@@ -337,10 +336,6 @@ class RayPPOTrainer(BaseRayPPOTrainer):
             logger.log(data=val_metrics, step=self.global_steps)
             if self.config.trainer.get("val_only", False):
                 return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
-            rollout_skip.wrap_generate_sequences()
 
         # add tqdm
         progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")


### PR DESCRIPTION
The legacy rolloutskip has been removed from verl and replaced by SkipManager. This PR removes the corresponding feature to ensure CI runs properly. However, the trainers in recipe have not been adapted yet — it's unclear whether the dapo algorithm requires additional adaptation work.