### PR TITLE
[recipe] feat: add gsm8k_outcome_gating — why the group-filter metric is safety-critical under shaped rewards

### DIFF
--- a/gsm8k_outcome_gating/README.md
+++ b/gsm8k_outcome_gating/README.md
@@ -1,0 +1,183 @@
+# gsm8k_outcome_gating — phantom advantages under shaped rewards, and the gate that kills them
+
+A small, fully-reproducible study of **when group filtering actually matters in GRPO**,
+run on a single RTX 5090 with Qwen2.5-1.5B-Instruct + LoRA on GSM8K (~50 min per arm).
+
+**TL;DR** — under a shaped reward with a mild length term, plain GRPO and a DAPO-style
+std filter both collapse to near-zero accuracy within 40 steps; a **binary-outcome gate**
+(zero the advantage of groups whose *raw outcome* is all-same) keeps training healthy at
+every phantom strength tested:
+
+| held-out EM @ step 40 | plain GRPO | DAPO-style std gate | **outcome gate** |
+|---|---|---|---|
+| shaped reward, λ=0.30 (n=3) | 0.102 ± 0.126 | 0.037 ± 0.007 | **0.753 ± 0.006** |
+
+All three arms start from the same val@0 ≈ 0.715. Same model, same data, same
+hyperparameters — the only difference is which groups' advantage is removed.
+
+## 1. The phantom
+
+Group-relative estimators (GRPO/DAPO/GSPO) normalize per group:
+`A = (r − mean(r)) / (std(r) + ε)`. With a **binary** reward, an all-fail group has
+`std = 0` and contributes nothing. DAPO's dynamic sampling therefore filters groups by
+**reward std**.
+
+Under a **shaped** reward that is exactly the DAPO assumption breaks: an all-fail group
+has `std > 0` (different partial credit per failure), so the std filter **keeps** it —
+and GRPO then normalizes the tiny shaping differences into full-size advantages. The
+group's gradient says nothing about solving the task; it says *"fail the way the shaping
+prefers."* We call this a **phantom advantage**.
+
+The shaped reward here makes the phantom concrete and tunable:
+
+```
+reward = outcome(0/1) − λ · min(len_chars / 512, 1)        # GATE_PHANTOM=short (default)
+```
+
+Among failures the shortest wrong answer scores best — "give up fast". This reproduces a
+failure mode we first hit in a search-agent setup where answer length collapsed from ~24
+to ~7 characters; here it is dialed in with a single knob λ.
+
+## 2. Design: a confound-free comparison
+
+Three arms, selected by `GATE_MODE`, all inside a wrapper around verl's
+`compute_advantage` ([gate_hook.py](gate_hook.py)):
+
+| arm | drops (advantage → 0) | rationale |
+|---|---|---|
+| `none` | nothing | plain GRPO control |
+| `std` | groups with reward std ≈ 0 | DAPO-style dynamic-sampling criterion |
+| `outcome` | groups whose **raw outcome** is all-same | the gate under test |
+
+Two design points that matter:
+
+- **Advantage-zeroing, not mask-zeroing.** Zeroing `response_mask` rows shrinks the
+  token-mean loss denominator, which multiplies the loss by `1/live_frac` — and Adam's
+  scale invariance then largely cancels it. (We measured this separately: under *binary*
+  rewards, mask-drop gating is a no-op that merely disguises a learning-rate change.)
+  Zeroing advantages leaves the denominator untouched, so the arms differ **only** in
+  which groups' gradient is removed.
+- **The gate groups on the raw outcome, not the shaped scalar.** The reward function
+  returns `{"score": shaped, "outcome_binary": outcome, "acc": outcome}`; the extra keys
+  ride through verl's `reward_extra_info` into `non_tensor_batch` (visible in logs as
+  `val-aux/openai/gsm8k/outcome_binary/mean@1`), so the outcome gate never confuses
+  "barely failed" with "passed".
+
+## 3. Experiment 1 — three arms, three independent replicates (λ = 0.30)
+
+| val EM | @0 | @10 | @20 | @30 | @40 | resp. len @40 (tokens) |
+|---|---|---|---|---|---|---|
+| none (replicate 1) | 0.725 | 0.733 | 0.613 | 0.487 | **0.247** | 18 |
+| std (replicate 1) | 0.717 | 0.701 | 0.531 | 0.267 | **0.044** | 3 |
+| outcome (replicate 1) | 0.716 | 0.731 | 0.746 | 0.771 | **0.755** | 244 |
+
+Endpoints across all three replicates:
+
+| val@40 | rep 1 | rep 2 | rep 3 | mean ± std |
+|---|---|---|---|---|
+| none | 0.247 | 0.038 | 0.022 | 0.102 ± 0.126 |
+| std | 0.044 | 0.031 | 0.037 | 0.037 ± 0.007 |
+| **outcome** | 0.755 | 0.758 | 0.747 | **0.753 ± 0.006** |
+
+Mechanism, from the gate's own logs: while accuracy is healthy the std gate drops only
+~2/32 degenerate groups per batch (the phantom groups all have std>0 and sail through),
+whereas the outcome gate drops 16–24/32 (all-pass + all-fail). The std filter only
+starts firing *after* the collapse homogenizes outputs (identical 1–3 token answers →
+std→0) — it removes the corpse, never the poison.
+
+## 4. Experiment 2 — dose-response over λ
+
+`GATE_LAMBDA` sweeps the phantom strength (0.30 anchor is the n=3 above; the new cells
+are single runs):
+
+| val@40 | λ=0.10 | λ=0.30 | λ=0.50 |
+|---|---|---|---|
+| none | 0.055 | 0.102 ± 0.126 | **0.000** |
+| std | 0.033 | 0.037 ± 0.007 | 0.021 |
+| outcome | 0.764 | 0.753 ± 0.006 | 0.736 |
+
+- **No safe dose.** Even λ=0.10 fully collapses both baselines within 40 steps; λ only
+  sets the collapse speed (mid-run EM orders monotonically with λ).
+- **The gate is immune at every dose.** Its mild slope (0.764 → 0.736) is consistent
+  with the residual, *legitimate* length penalty that shaping applies to correct answers
+  inside live groups.
+- At λ=0.50 plain GRPO reaches EM 0.000 with mean response length **1.0 token** — the
+  policy learns that shutting up immediately is optimal.
+- Plumbing canary: at step 1, `critic/rewards/min` equals exactly −λ (−0.5 / −0.3),
+  proving the env knob reaches the Ray reward workers.
+
+## 5. Experiment 3 — reverse phantom (the Goodhart asymmetry)
+
+`GATE_PHANTOM=long` flips the length term so the **longest** wrong answer scores best
+(λ=0.30, single runs):
+
+| val@40 | phantom=short | phantom=long |
+|---|---|---|
+| none | 0.102 ± 0.126 💥 | 0.736 ✅ |
+| std | 0.037 ± 0.007 💥 | 0.746 ✅ |
+| outcome | 0.753 ± 0.006 ✅ | 0.754 ✅ |
+
+Nobody collapses: mean length drifts up ~15% and then saturates, EM is untouched. The
+asymmetry is informative: a phantom is lethal only when its shortcut **destroys task
+structure** (truncation deletes the answer itself; padding leaves it intact, and in
+mixed groups the +1.0 for a correct answer dwarfs the shaping term, so the phantom
+never steers). Footnote: the outcome arm shows the *tightest* length curve of the
+three — the gate suppresses even the harmless style drift.
+
+## 6. Honesty & limitations
+
+- **"Independent replicates", not "seeds".** The three Experiment-1 runs used identical
+  configs (verl default seed) and differ through rollout/scheduling nondeterminism.
+  That is exactly the run-to-run variance that plagues n=1 RL A/Bs — the effect
+  (gap ≥ 0.65) dwarfs it (replicate std ≤ 0.13). The launcher now supports true seed
+  injection (`REALSEED=…` sets `rollout.seed` + `data.seed`) for stricter runs.
+- Experiment 2/3 off-anchor cells are **n=1**; read them as trends anchored by the n=3
+  column, not as precise point estimates.
+- One model (Qwen2.5-1.5B-Instruct, LoRA r=32), one task (GSM8K), 40 steps. The claim
+  is mechanistic (which groups carry the phantom gradient and who drops them), not a
+  leaderboard result.
+- EM uses a deliberately forgiving extractor (`####`, `\boxed{}`, "answer is", last
+  number) so the collapse numbers measure lost ability, not lost formatting.
+
+## 7. Reproduce
+
+```bash
+# 0) pinned verl (see REQUIRED_VERL.txt), plus a venv with vllm 0.11.0 / torch 2.8.0
+pip install "verl @ git+https://github.com/verl-project/verl.git@e52747a403f55044578d9435069825f949b549bf"
+
+# 1) offline sanity (no GPU needed)
+python test_gate_offline.py
+
+# 2) wire the gate into the venv (reversible; inert without GATE_* env vars)
+./install_gate.sh /path/to/venv/bin/python
+
+# 3) data + model under $GATE_ROOT
+#    - GSM8K parquet via verl's examples/data_preprocess/gsm8k.py -> $GATE_ROOT/data/gsm8k/
+#    - Qwen2.5-1.5B-Instruct              -> $GATE_ROOT/models/qwen25-1.5b-instruct
+
+# 4) the three experiments (each arm ~50 min on one RTX 5090)
+GATE_ROOT=... VERL_VENV=... ./run_gate_chain.sh      # Exp 1 (repeat with TAG=r2, r3)
+GATE_ROOT=... VERL_VENV=... ./run_lambda_chain.sh    # Exp 2
+GATE_ROOT=... VERL_VENV=... ./run_phantom_chain.sh   # Exp 3
+```
+
+Per-arm curves land in `$GATE_ROOT/gate_results/*.md`; raw logs in `$GATE_ROOT/*.log`
+(`grep -aoE "acc[^ ]*mean@1:np.float64\([0-9.]+\)"` extracts the EM curve).
+
+## Files
+
+| file | role |
+|---|---|
+| [gate_hook.py](gate_hook.py) | advantage-zeroing gate around `compute_advantage` (`GATE_MODE`) |
+| [gate_shaped_reward.py](gate_shaped_reward.py) | shaped GSM8K reward (`GATE_LAMBDA`, `GATE_PHANTOM`) |
+| [sitecustomize.py](sitecustomize.py) | loads the hook inside every Ray worker |
+| [install_gate.sh](install_gate.sh) | one-shot wiring (.pth + built-in reward branch), documented + reversible |
+| [run_gate_arm.sh](run_gate_arm.sh) | single-arm launcher (all hydra flags) |
+| [run_gate_chain.sh](run_gate_chain.sh) / [run_lambda_chain.sh](run_lambda_chain.sh) / [run_phantom_chain.sh](run_phantom_chain.sh) | Experiments 1 / 2 / 3 |
+| [test_gate_offline.py](test_gate_offline.py) | no-GPU tests for partitioning, zeroing, both phantom directions |
+| [REQUIRED_VERL.txt](REQUIRED_VERL.txt) | pinned verl commit + stack versions |
+
+### Required `verl` version
+
+See [REQUIRED_VERL.txt](REQUIRED_VERL.txt) — `MODE=pinned_commit` at the exact commit
+every number above was produced against.

--- a/gsm8k_outcome_gating/README.md
+++ b/gsm8k_outcome_gating/README.md
@@ -1,32 +1,49 @@
-# gsm8k_outcome_gating — phantom advantages under shaped rewards, and the gate that kills them
+# gsm8k_outcome_gating — why the group-filter *metric* is safety-critical under shaped rewards
 
 A small, fully-reproducible study of **when group filtering actually matters in GRPO**,
 run on a single RTX 5090 with Qwen2.5-1.5B-Instruct + LoRA on GSM8K (~50 min per arm).
 
-**TL;DR** — under a shaped reward with a mild length term, plain GRPO and a DAPO-style
-std filter both collapse to near-zero accuracy within 40 steps; a **binary-outcome gate**
-(zero the advantage of groups whose *raw outcome* is all-same) keeps training healthy at
-every phantom strength tested:
+**TL;DR** — `filter_groups.metric` decides whether dynamic sampling protects you or not.
+Every official DAPO script in this repo sets `filter_groups_metric=acc`, and that choice
+is load-bearing: filtering on the **binary outcome** stays safe under reward shaping,
+while filtering on the **shaped training reward** (`score` / `seq_reward` — the natural-looking
+choice once you have a shaped reward) silently stops dropping all-fail groups and lets a
+phantom gradient destroy the policy in 40 steps:
 
-| held-out EM @ step 40 | plain GRPO | DAPO-style std gate | **outcome gate** |
+| held-out EM @ step 40 | no filtering (plain GRPO) | filter on **shaped score** | filter on **binary outcome** (= `metric=acc`) |
 |---|---|---|---|
 | shaped reward, λ=0.30 (n=3) | 0.102 ± 0.126 | 0.037 ± 0.007 | **0.753 ± 0.006** |
 
 All three arms start from the same val@0 ≈ 0.715. Same model, same data, same
-hyperparameters — the only difference is which groups' advantage is removed.
+hyperparameters — the only difference is which groups' advantage is removed. **~19× on a
+config field**, plus the dose-response and direction-asymmetry boundaries below.
 
 ## 1. The phantom
 
 Group-relative estimators (GRPO/DAPO/GSPO) normalize per group:
 `A = (r − mean(r)) / (std(r) + ε)`. With a **binary** reward, an all-fail group has
-`std = 0` and contributes nothing. DAPO's dynamic sampling therefore filters groups by
-**reward std**.
+`std = 0` and contributes nothing — which is why DAPO filters those groups out.
 
-Under a **shaped** reward that is exactly the DAPO assumption breaks: an all-fail group
-has `std > 0` (different partial credit per failure), so the std filter **keeps** it —
-and GRPO then normalizes the tiny shaping differences into full-size advantages. The
-group's gradient says nothing about solving the task; it says *"fail the way the shaping
-prefers."* We call this a **phantom advantage**.
+veRL implements that filter as *"drop groups whose `filter_groups.metric` is all-same"*
+([`dapo_ray_trainer.py`](../dapo/dapo_ray_trainer.py)), and the metric is configurable.
+The DAPO paper's criterion is accuracy-based, and every official script in
+[`recipe/dapo`](../dapo) sets `filter_groups_metric=acc` — under that configuration the
+filter is **outcome-based and stays correct even when the reward is shaped**, because
+`acc` remains binary no matter what shaping does to `score`.
+
+The failure mode this recipe isolates is what happens when the filter metric is the
+**shaped training reward** instead (`score` / `seq_reward` — both are valid values of the
+field, and reaching for "the reward I train on" is the natural move once shaping exists).
+Then an all-fail group has `std > 0` (different partial credit per failure), the filter
+**keeps** it, and GRPO normalizes the tiny shaping differences into full-size advantages.
+That group's gradient says nothing about solving the task; it says *"fail the way the
+shaping prefers."* We call this a **phantom advantage**.
+
+So the contribution here is not a flaw in DAPO — it is a measurement of how much that one
+config field is worth (~19×), why the safe choice is safe, and where its boundaries lie.
+**Practical rule: any project that adds reward shaping must expose a binary correctness
+signal decoupled from the shaped reward, and filter on that** — otherwise dynamic sampling
+degrades silently, with no error and no warning.
 
 The shaped reward here makes the phantom concrete and tunable:
 
@@ -43,11 +60,11 @@ to ~7 characters; here it is dialed in with a single knob λ.
 Three arms, selected by `GATE_MODE`, all inside a wrapper around verl's
 `compute_advantage` ([gate_hook.py](gate_hook.py)):
 
-| arm | drops (advantage → 0) | rationale |
+| arm | drops (advantage → 0) | corresponds to |
 |---|---|---|
-| `none` | nothing | plain GRPO control |
-| `std` | groups with reward std ≈ 0 | DAPO-style dynamic-sampling criterion |
-| `outcome` | groups whose **raw outcome** is all-same | the gate under test |
+| `none` | nothing | no dynamic sampling (plain GRPO control) |
+| `std` | groups whose **shaped reward** std ≈ 0 | `filter_groups.metric = score` / `seq_reward` |
+| `outcome` | groups whose **binary outcome** is all-same | `filter_groups.metric = acc` (every official DAPO script) |
 
 Two design points that matter:
 
@@ -60,28 +77,28 @@ Two design points that matter:
 - **The gate groups on the raw outcome, not the shaped scalar.** The reward function
   returns `{"score": shaped, "outcome_binary": outcome, "acc": outcome}`; the extra keys
   ride through verl's `reward_extra_info` into `non_tensor_batch` (visible in logs as
-  `val-aux/openai/gsm8k/outcome_binary/mean@1`), so the outcome gate never confuses
+  `val-aux/openai/gsm8k/outcome_binary/mean@1`), so outcome-based filtering never confuses
   "barely failed" with "passed".
 
 ## 3. Experiment 1 — three arms, three independent replicates (λ = 0.30)
 
 | val EM | @0 | @10 | @20 | @30 | @40 | resp. len @40 (tokens) |
 |---|---|---|---|---|---|---|
-| none (replicate 1) | 0.725 | 0.733 | 0.613 | 0.487 | **0.247** | 18 |
-| std (replicate 1) | 0.717 | 0.701 | 0.531 | 0.267 | **0.044** | 3 |
-| outcome (replicate 1) | 0.716 | 0.731 | 0.746 | 0.771 | **0.755** | 244 |
+| no-filter (replicate 1) | 0.725 | 0.733 | 0.613 | 0.487 | **0.247** | 18 |
+| shaped-score (replicate 1) | 0.717 | 0.701 | 0.531 | 0.267 | **0.044** | 3 |
+| binary-outcome (replicate 1) | 0.716 | 0.731 | 0.746 | 0.771 | **0.755** | 244 |
 
 Endpoints across all three replicates:
 
 | val@40 | rep 1 | rep 2 | rep 3 | mean ± std |
 |---|---|---|---|---|
-| none | 0.247 | 0.038 | 0.022 | 0.102 ± 0.126 |
-| std | 0.044 | 0.031 | 0.037 | 0.037 ± 0.007 |
-| **outcome** | 0.755 | 0.758 | 0.747 | **0.753 ± 0.006** |
+| no-filter | 0.247 | 0.038 | 0.022 | 0.102 ± 0.126 |
+| shaped-score | 0.044 | 0.031 | 0.037 | 0.037 ± 0.007 |
+| **binary-outcome** | 0.755 | 0.758 | 0.747 | **0.753 ± 0.006** |
 
-Mechanism, from the gate's own logs: while accuracy is healthy the std gate drops only
+Mechanism, from the hook's own logs: while accuracy is healthy the shaped-score filter drops only
 ~2/32 degenerate groups per batch (the phantom groups all have std>0 and sail through),
-whereas the outcome gate drops 16–24/32 (all-pass + all-fail). The std filter only
+whereas the binary-outcome filter drops 16–24/32 (all-pass + all-fail). The shaped-score filter only
 starts firing *after* the collapse homogenizes outputs (identical 1–3 token answers →
 std→0) — it removes the corpse, never the poison.
 
@@ -92,13 +109,13 @@ are single runs):
 
 | val@40 | λ=0.10 | λ=0.30 | λ=0.50 |
 |---|---|---|---|
-| none | 0.055 | 0.102 ± 0.126 | **0.000** |
-| std | 0.033 | 0.037 ± 0.007 | 0.021 |
-| outcome | 0.764 | 0.753 ± 0.006 | 0.736 |
+| no-filter | 0.055 | 0.102 ± 0.126 | **0.000** |
+| shaped-score | 0.033 | 0.037 ± 0.007 | 0.021 |
+| binary-outcome | 0.764 | 0.753 ± 0.006 | 0.736 |
 
 - **No safe dose.** Even λ=0.10 fully collapses both baselines within 40 steps; λ only
   sets the collapse speed (mid-run EM orders monotonically with λ).
-- **The gate is immune at every dose.** Its mild slope (0.764 → 0.736) is consistent
+- **The binary-outcome filter is immune at every dose.** Its mild slope (0.764 → 0.736) is consistent
   with the residual, *legitimate* length penalty that shaping applies to correct answers
   inside live groups.
 - At λ=0.50 plain GRPO reaches EM 0.000 with mean response length **1.0 token** — the
@@ -113,19 +130,24 @@ are single runs):
 
 | val@40 | phantom=short | phantom=long |
 |---|---|---|
-| none | 0.102 ± 0.126 💥 | 0.736 ✅ |
-| std | 0.037 ± 0.007 💥 | 0.746 ✅ |
-| outcome | 0.753 ± 0.006 ✅ | 0.754 ✅ |
+| no-filter | 0.102 ± 0.126 💥 | 0.736 ✅ |
+| shaped-score | 0.037 ± 0.007 💥 | 0.746 ✅ |
+| binary-outcome | 0.753 ± 0.006 ✅ | 0.754 ✅ |
 
 Nobody collapses: mean length drifts up ~15% and then saturates, EM is untouched. The
 asymmetry is informative: a phantom is lethal only when its shortcut **destroys task
 structure** (truncation deletes the answer itself; padding leaves it intact, and in
 mixed groups the +1.0 for a correct answer dwarfs the shaping term, so the phantom
-never steers). Footnote: the outcome arm shows the *tightest* length curve of the
-three — the gate suppresses even the harmless style drift.
+never steers). Footnote: the binary-outcome arm shows the *tightest* length curve of the
+three — outcome-based filtering suppresses even the harmless style drift.
 
 ## 6. Honesty & limitations
 
+- **This is not a defect report against DAPO.** The DAPO paper's dynamic-sampling
+  criterion is accuracy-based, and every official script here sets
+  `filter_groups_metric=acc`, which is the safe configuration measured above. What this
+  recipe quantifies is the cost of the *other* valid settings of that field once a shaped
+  reward is in play, and the reason the safe one is safe.
 - **"Independent replicates", not "seeds".** The three Experiment-1 runs used identical
   configs (verl default seed) and differ through rollout/scheduling nondeterminism.
   That is exactly the run-to-run variance that plagues n=1 RL A/Bs — the effect
@@ -168,7 +190,7 @@ Per-arm curves land in `$GATE_ROOT/gate_results/*.md`; raw logs in `$GATE_ROOT/*
 
 | file | role |
 |---|---|
-| [gate_hook.py](gate_hook.py) | advantage-zeroing gate around `compute_advantage` (`GATE_MODE`) |
+| [gate_hook.py](gate_hook.py) | advantage-zeroing filter around `compute_advantage` (`GATE_MODE` selects the metric) |
 | [gate_shaped_reward.py](gate_shaped_reward.py) | shaped GSM8K reward (`GATE_LAMBDA`, `GATE_PHANTOM`) |
 | [sitecustomize.py](sitecustomize.py) | loads the hook inside every Ray worker |
 | [install_gate.sh](install_gate.sh) | one-shot wiring (.pth + built-in reward branch), documented + reversible |

--- a/gsm8k_outcome_gating/REQUIRED_VERL.txt
+++ b/gsm8k_outcome_gating/REQUIRED_VERL.txt
@@ -1,0 +1,6 @@
+# gsm8k_outcome_gating — pinned to the verl commit every experiment ran against
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=pinned_commit
+COMMIT=e52747a403f55044578d9435069825f949b549bf
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@e52747a403f55044578d9435069825f949b549bf
+NOTES=All numbers in README.md were produced at this commit (2026-07-07) with vLLM 0.11.0 / torch 2.8.0 / transformers 4.57.6 on python 3.10, single RTX 5090 (LoRA r=32, ~50 min per 40-step arm). Newer main revisions are untested here, not known-broken: the recipe touches verl only through install_gate.sh (a .pth for Ray-worker injection plus a 6-line env-gated branch in the built-in gsm8k reward, reversible via the .bak backup).

--- a/gsm8k_outcome_gating/gate_hook.py
+++ b/gsm8k_outcome_gating/gate_hook.py
@@ -1,0 +1,136 @@
+"""
+gate_hook — the "correct test" for outcome-gating, wired into veRL's compute_advantage.
+
+The scientific question (the user's own next-step, from the tau2 work):
+    Under a SHAPED reward, an all-FAIL group can have std>0 (different partial credit per
+    failed rollout). DAPO's std-based dynamic sampling KEEPS such a group (std>0) and GRPO then
+    fabricates a "phantom advantage" inside it — rewarding the least-bad failure (e.g. the
+    shortest give-up). A BINARY-OUTCOME gate drops the group (all same outcome) and kills the
+    phantom. So binary-outcome gating catches exactly what DAPO's std filter misses.
+
+GATE_MODE env selects the arm:
+    none    — plain GRPO (control)
+    std     — DAPO-style: zero advantage on groups whose reward std ≈ 0
+    outcome — binary-outcome gate: zero advantage on groups whose OUTCOME is all-same
+
+★ Design choice that matters: we ZERO THE ADVANTAGES of gated rows, we do NOT zero response_mask.
+  The token-mean denominator (loss_mask.sum()) is therefore UNCHANGED across all three arms, so
+  this comparison is FREE of the 1/live_frac learning-rate confound (which the GSM8K/MATH bake-off
+  showed is what mask-dropping really does). The only thing that varies between arms is which
+  groups' gradient is removed — exactly the intervention under test.
+
+Installed via the same .pth + sitecustomize mechanism as the py3.10 compat shim, so it lands in
+the Ray worker where compute_advantage runs. No-op unless GATE_MODE is set.
+"""
+
+from __future__ import annotations
+
+import os
+
+STD_EPS = 1e-6  # a group with reward spread below this is "no contrast" (DAPO would drop it)
+
+
+def _enabled() -> bool:
+    return os.environ.get("GATE_MODE") in ("none", "std", "outcome")
+
+
+def partition(index, outcome, reward, mode):
+    """Return (drop_row_ids, stats). index/outcome/reward are per-row lists (len = n_rows)."""
+    groups = {}
+    for i, uid in enumerate(index):
+        groups.setdefault(uid, []).append(i)
+    drop = []
+    dead_groups = 0
+    for uid, rows in groups.items():
+        outs = [outcome[i] for i in rows]
+        rews = [reward[i] for i in rows]
+        if mode == "std":
+            mean = sum(rews) / len(rews)
+            var = sum((r - mean) ** 2 for r in rews) / len(rews)
+            is_dead = var**0.5 <= STD_EPS  # no reward contrast at all
+        elif mode == "outcome":
+            is_dead = len(set(outs)) == 1  # all-same OUTCOME (all-fail or all-pass)
+        else:  # none
+            is_dead = False
+        if is_dead:
+            drop.extend(rows)
+            dead_groups += 1
+    stats = {
+        "mode": mode,
+        "total_groups": len(groups),
+        "dead_groups": dead_groups,
+        "total_rows": len(index),
+        "dropped_rows": len(drop),
+        "live_frac": round(1 - len(drop) / max(1, len(index)), 4),
+    }
+    return drop, stats
+
+
+def zero_adv(adv, drop_rows):
+    """Zero the advantage of dropped rows. adv: torch/np [n_rows, seq] or [n_rows]. Returns adv."""
+    if not drop_rows:
+        return adv
+    import numpy as np
+
+    idx = list(drop_rows)
+    if hasattr(adv, "index_fill_"):  # torch
+        import torch
+
+        t = torch.tensor(idx, dtype=torch.long, device=adv.device)
+        adv.index_fill_(0, t, 0.0)
+        return adv
+    adv[np.asarray(idx)] = 0.0  # numpy
+    return adv
+
+
+def _row_outcomes(data):
+    """Per-row (reward_scalar, binary_outcome). outcome from the raw success signal, not shaped."""
+    # outcome_binary: exposed by the shaped reward via extra_info if present; else threshold scores.
+    ntb = data.non_tensor_batch
+    scores = data.batch["token_level_scores"]
+    row_reward = scores.sum(dim=-1) if scores.dim() > 1 else scores
+    row_reward = row_reward.detach().cpu().tolist()
+    if "outcome_binary" in ntb:
+        outcome = [int(x) for x in ntb["outcome_binary"]]
+    else:
+        outcome = [1 if r > 0.5 else 0 for r in row_reward]  # fallback: shaped>0.5 ~ pass
+    return row_reward, outcome
+
+
+def install():
+    if not _enabled():
+        return
+    mode = os.environ["GATE_MODE"]
+    if mode == "none":
+        print("[gate] GATE_MODE=none — plain GRPO, no hook installed", flush=True)
+        return
+    from verl.trainer.ppo import ray_trainer
+
+    if getattr(ray_trainer, "_gate_installed", False):
+        return
+    import functools
+
+    _orig = ray_trainer.compute_advantage
+
+    @functools.wraps(_orig)
+    def compute_advantage_gated(data, *args, **kwargs):
+        data = _orig(data, *args, **kwargs)
+        ntb = data.non_tensor_batch
+        if "uid" not in ntb:
+            raise RuntimeError("gate_hook: batch has no uid; cannot group.")
+        index = list(ntb["uid"])
+        row_reward, outcome = _row_outcomes(data)
+        drop, st = partition(index, outcome, row_reward, mode)
+        if drop:
+            data.batch["advantages"] = zero_adv(data.batch["advantages"], drop)
+        print(
+            f"[gate] mode={mode} live_frac={st['live_frac']} "
+            f"dropped_rows={st['dropped_rows']}/{st['total_rows']} "
+            f"dead_groups={st['dead_groups']}/{st['total_groups']} (advantage-zeroed, denom unchanged)",
+            flush=True,
+        )
+        return data
+
+    ray_trainer.compute_advantage = compute_advantage_gated
+    ray_trainer._gate_installed = True
+    print(f"[gate] installed: mode={mode} (advantage-zeroing, confound-free)", flush=True)

--- a/gsm8k_outcome_gating/gate_shaped_reward.py
+++ b/gsm8k_outcome_gating/gate_shaped_reward.py
@@ -1,0 +1,61 @@
+"""
+Shaped GSM8K reward for the outcome-gating "correct test".
+
+    reward = outcome(0/1)  -  LAMBDA * norm_length
+
+The length term is the phantom: among FAILURES it rewards the *shortest* wrong answer (give up
+faster) — the documented Goodhart trap (the search-agent's 24→7-char answer-length collapse). So
+an all-fail group has std>0 (different lengths → different reward), which DAPO's std filter keeps
+and GRPO turns into a phantom gradient; the binary-outcome gate drops it.
+
+Exposes `outcome_binary` (the UNSHAPED correctness) via the score dict so the gate groups on the
+real outcome, not the shaped scalar. veRL's reward manager returns the scalar as the token-level
+score; the extra key rides along in extra_info handling where supported, else the gate falls back
+to thresholding — but we ALSO stash it so the run log can be audited.
+
+compute_score(data_source, solution_str, ground_truth, extra_info=None) -> dict|float
+"""
+
+import os
+import re
+
+LAMBDA = float(os.environ.get("GATE_LAMBDA", "0.30"))  # phantom strength; env-swept for dose-response
+PHANTOM = os.environ.get("GATE_PHANTOM", "short")  # short: reward brevity in failures / long: reward verbosity
+LEN_CAP = 512  # chars; responses at/above this get full length penalty
+
+
+def _extract(text):
+    """Flexible GSM8K answer extraction: #### , \\boxed{}, 'answer is', else last number."""
+    if text is None:
+        return None
+    for pat in (
+        r"####\s*([+-]?[\d,]+(?:\.\d+)?)",
+        r"\\boxed\{\s*([+-]?[\d,]+(?:\.\d+)?)\s*\}",
+        r"(?:answer|result)\s*(?:is|:|=)\s*\$?\s*([+-]?[\d,]+(?:\.\d+)?)",
+    ):
+        m = re.findall(pat, text, flags=re.IGNORECASE)
+        if m:
+            return m[-1].replace(",", "").rstrip(".")
+    nums = re.findall(r"[-+]?\d[\d,]*(?:\.\d+)?", text)
+    return nums[-1].replace(",", "").rstrip(".") if nums else None
+
+
+def _correct(solution_str, ground_truth):
+    pred = _extract(solution_str)
+    if pred is None:
+        return 0
+    gold = str(ground_truth).replace(",", "").strip()
+    gold = _extract(gold) or gold
+    try:
+        return int(abs(float(pred) - float(gold)) < 1e-4)
+    except ValueError:
+        return int(pred == gold)
+
+
+def compute_score(data_source, solution_str, ground_truth, extra_info=None):
+    outcome = _correct(solution_str, ground_truth)
+    norm_len = min(len(solution_str or "") / LEN_CAP, 1.0)
+    pen = norm_len if PHANTOM == "short" else (1.0 - norm_len)
+    shaped = float(outcome) - LAMBDA * pen
+    # Return a dict so the outcome rides along; veRL uses "score" as the scalar reward.
+    return {"score": shaped, "outcome_binary": outcome, "acc": float(outcome)}

--- a/gsm8k_outcome_gating/install_gate.sh
+++ b/gsm8k_outcome_gating/install_gate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Wire the gate into a pinned-verl installation. Two small, reversible steps:
+#
+#  1. Drop zzz_gate_path.pth into the venv's site-packages so every process —
+#     including Ray workers — imports this directory's sitecustomize.py, which
+#     installs gate_hook when GATE_MODE is set.
+#     Why not monkey-patch from the driver? compute_advantage runs inside the
+#     TaskRunner Ray actor (a separate process); a driver-side patch never
+#     reaches it. The .pth + sitecustomize route is what actually lands there.
+#
+#  2. Insert a 6-line env-gated branch at the top of verl's built-in gsm8k
+#     reward (backed up to gsm8k.py.bak). Why not data.custom_reward_function?
+#     At the pinned commit the async agent-loop reward path (RewardLoopWorker)
+#     bypasses it, so the built-in must carry the branch. The branch is inert
+#     unless GATE_SHAPED is set.
+#
+# Usage:   ./install_gate.sh /path/to/venv/bin/python
+# Undo:    restore gsm8k.py.bak and delete zzz_gate_path.pth from site-packages.
+# ==============================================================================
+set -euo pipefail
+VENV_PY=${1:?usage: install_gate.sh /path/to/venv/bin/python}
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+SITE=$("$VENV_PY" -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
+echo "import sys; sys.path.insert(0, \"$HERE\")" > "$SITE/zzz_gate_path.pth"
+echo "[install_gate] wrote $SITE/zzz_gate_path.pth"
+
+GSM=$("$VENV_PY" - <<'PY'
+import verl.utils.reward_score.gsm8k as m
+print(m.__file__)
+PY
+)
+if grep -q "GATE_SHAPED" "$GSM"; then
+  echo "[install_gate] reward branch already present in $GSM"
+else
+  cp "$GSM" "$GSM.bak"
+  "$VENV_PY" - "$GSM" "$HERE" <<'PY'
+import re
+import sys
+
+path, here = sys.argv[1], sys.argv[2]
+src = open(path).read()
+m = re.search(r"^def compute_score\(.*\):\n", src, flags=re.M)
+if not m:
+    raise SystemExit(f"[install_gate] could not find 'def compute_score(...):' in {path}; patch by hand")
+branch = (
+    f"    import os as _os\n"
+    f"    if _os.environ.get(\"GATE_SHAPED\"):\n"
+    f"        import sys as _sys\n"
+    f"        if \"{here}\" not in _sys.path: _sys.path.insert(0, \"{here}\")\n"
+    f"        import gate_shaped_reward as _gsr\n"
+    f"        return _gsr.compute_score(\"openai/gsm8k\", solution_str, ground_truth)\n\n"
+)
+src = src[: m.end()] + branch + src[m.end() :]
+open(path, "w").write(src)
+print(f"[install_gate] patched {path} (backup: {path}.bak)")
+PY
+fi
+echo "[install_gate] done. The gate is inert unless GATE_SHAPED / GATE_MODE are set."

--- a/gsm8k_outcome_gating/run_gate_arm.sh
+++ b/gsm8k_outcome_gating/run_gate_arm.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Single-arm launcher — GSM8K x Qwen2.5-1.5B-Instruct, GRPO + LoRA(r=32), 1 GPU.
+# This is the launcher that produced every number in README.md (machine-specific
+# absolute paths replaced by env vars; hydra flags unchanged). Ran on a single
+# RTX 5090: hybrid engine, rollout TP=1, no flash-attn (sdpa fallback).
+#
+# Env knobs:
+#   GATE_ROOT     work dir holding data/ models/ logs   (default: ./work)
+#   VERL_VENV     venv with the pinned verl installed   (default: $GATE_ROOT/venv)
+#   MODEL_PATH    policy model                          (default: $GATE_ROOT/models/qwen25-1.5b-instruct)
+#   GPU           CUDA device index                     (default: 0)
+#   ADV           advantage estimator                   (default: grpo)
+#   LR            actor lr                              (default: 1e-4)
+#   MAX_STEPS     total training steps                  (default: 40)
+#   GUTIL         vllm gpu_memory_utilization           (default: 0.3)
+#   EXP           experiment name / log file stem       (default: gate_grpo)
+#   PRECHECK_MAX  refuse to start if GPU already uses more MiB (default: 15000)
+#   HF_MIRROR=1   route HF downloads through hf-mirror.com
+#   The gate itself (read by the hook / reward inside Ray workers):
+#   GATE_SHAPED=1 route the gsm8k reward through gate_shaped_reward.py
+#   GATE_MODE     none | std | outcome                  (which arm)
+#   GATE_LAMBDA   phantom strength                      (default: 0.30)
+#   GATE_PHANTOM  short | long                          (default: short)
+#   REALSEED      inject rollout.seed + data.seed       (default: off)
+# ==============================================================================
+set -xeuo pipefail
+
+ROOT=${GATE_ROOT:-$(pwd)/work}
+VENV=${VERL_VENV:-$ROOT/venv}
+
+# ---- keep every cache / tmp off the system disk ----
+export TMPDIR=$ROOT/tmp
+export HF_HOME=$ROOT/.hfhome
+[ -n "${HF_MIRROR:-}" ] && export HF_ENDPOINT=https://hf-mirror.com
+export VLLM_CACHE_ROOT=$ROOT/.vllmcache
+export TRITON_CACHE_DIR=$ROOT/.triton
+export TORCHINDUCTOR_CACHE_DIR=$ROOT/.inductor
+export XDG_CACHE_HOME=$ROOT/.xdgcache
+export RAY_TMPDIR=$ROOT/tmp
+export VLLM_USE_V1=1
+mkdir -p "$TMPDIR" "$HF_HOME" "$VLLM_CACHE_ROOT" "$TRITON_CACHE_DIR" "$TORCHINDUCTOR_CACHE_DIR" "$XDG_CACHE_HOME"
+
+export CUDA_VISIBLE_DEVICES=${GPU:-0}
+
+# ---- shared-machine precheck: refuse to start on a busy GPU ----
+used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits -i "${CUDA_VISIBLE_DEVICES}" | tr -d " ")
+echo "[precheck] GPU ${CUDA_VISIBLE_DEVICES} used ${used} MiB"
+if [ "${used}" -gt "${PRECHECK_MAX:-15000}" ]; then
+  echo "[ABORT] GPU ${CUDA_VISIBLE_DEVICES} is busy (${used} MiB). Pick another: GPU=1 bash $0"
+  exit 1
+fi
+
+source "$VENV/bin/activate"
+cd "$ROOT"
+
+MODEL_PATH=${MODEL_PATH:-$ROOT/models/qwen25-1.5b-instruct}
+TRAIN_FILE=$ROOT/data/gsm8k/train.parquet
+TEST_FILE=$ROOT/data/gsm8k/test.parquet
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=${ADV:-grpo} \
+    data.train_files="$TRAIN_FILE" \
+    data.val_files="$TEST_FILE" \
+    data.train_batch_size=32 \
+    data.max_prompt_length=512 \
+    data.max_response_length=512 \
+    data.filter_overlong_prompts=True \
+    data.truncation=error \
+    actor_rollout_ref.model.path="$MODEL_PATH" \
+    actor_rollout_ref.model.use_remove_padding=False \
+    +actor_rollout_ref.model.override_config.attn_implementation=sdpa \
+    actor_rollout_ref.model.lora_rank=32 \
+    actor_rollout_ref.model.lora_alpha=32 \
+    actor_rollout_ref.model.target_modules=all-linear \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=${LR:-1e-4} \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.max_model_len=2048 \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=${GUTIL:-0.3} \
+    actor_rollout_ref.rollout.n=5 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.use_v1=False \
+    trainer.critic_warmup=0 \
+    trainer.logger=[console,tensorboard] \
+    trainer.val_before_train=True \
+    trainer.n_gpus_per_node=1 \
+    trainer.nnodes=1 \
+    trainer.project_name=gate_study \
+    trainer.experiment_name=${EXP:-gate_grpo} \
+    trainer.default_local_dir=$ROOT/ckpts/gate_study \
+    trainer.save_freq=-1 \
+    trainer.test_freq=5 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=${MAX_STEPS:-40} \
+    ${REALSEED:+actor_rollout_ref.rollout.seed=$REALSEED} \
+    ${REALSEED:+data.seed=$REALSEED} \
+    2>&1 | tee "$ROOT/${EXP:-gate_grpo}.log"

--- a/gsm8k_outcome_gating/run_gate_chain.sh
+++ b/gsm8k_outcome_gating/run_gate_chain.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Experiment 1 — the three-arm "correct test" under the shaped reward:
+#   none    — plain GRPO            (phantom gradient active)
+#   std     — DAPO-style std gate   (keeps all-fail groups with std>0 -> misses the phantom)
+#   outcome — binary-outcome gate   (drops all-same-outcome groups -> kills the phantom)
+# Advantage-zeroing (not mask-zeroing): the token-mean denominator is unchanged,
+# so the comparison is free of the 1/live_frac learning-rate confound.
+# Repeat this chain to get independent replicates (README reports n=3).
+set -uo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=${GATE_ROOT:-$(pwd)/work}
+PY=${VERL_VENV:-$ROOT/venv}/bin/python
+RES=$ROOT/gate_results
+mkdir -p "$RES"
+STEPS=${STEPS:-40}
+TAG=${TAG:-r1}          # replicate tag: r1, r2, ... (README's runs used per-run tags)
+
+run() {
+  local mode="$1" exp="gate_${mode}_${TAG}" log="$ROOT/gate_${mode}_${TAG}.log"
+  echo "======== $(date) START $exp ========"
+  "$PY" -m ray stop --force >/dev/null 2>&1
+  for p in $(pgrep -u "$(id -un)" -f "verl.trainer.main_ppo"); do kill -9 "$p" 2>/dev/null; done
+  sleep 10
+  env GPU="${GPU:-0}" ADV=grpo LR="${LR:-1e-4}" MAX_STEPS="$STEPS" GUTIL="${GUTIL:-0.3}" \
+      GATE_SHAPED=1 GATE_MODE="$mode" GATE_LAMBDA="${GATE_LAMBDA:-0.30}" EXP="$exp" \
+      GATE_ROOT="$ROOT" VERL_VENV="${VERL_VENV:-$ROOT/venv}" \
+      bash "$HERE/run_gate_arm.sh" >> "$log" 2>&1
+  {
+    echo "# $exp done $(date)"
+    echo -n "em: "; grep -aoE "acc[^ ]*mean@1:np.float64\([0-9.]+\)" "$log" | sed -E "s/.*\(([0-9.]+)\)/\1/" | cut -c1-6 | paste -sd" "
+    echo -n "gate_last: "; grep -a "\[gate\]" "$log" | tail -1 | grep -aoE "live_frac=[0-9.]+ dropped_rows=[0-9/]+"; echo
+    echo -n "len_last: "; grep -aoE "response_length/mean:[0-9]+" "$log" | tail -1
+  } > "$RES/${exp}.md"
+  echo "ARM_DONE $exp"; cat "$RES/${exp}.md"
+}
+
+run none
+run std
+run outcome
+echo "CHAIN_COMPLETE $(date)"

--- a/gsm8k_outcome_gating/run_lambda_chain.sh
+++ b/gsm8k_outcome_gating/run_lambda_chain.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Experiment 2 — dose-response over phantom strength lambda.
+# The lambda=0.30 anchor comes from run_gate_chain.sh (n=3 in README); this
+# chain adds lambda in {0.50, 0.10} x {none, std, outcome}. The 0.50/none arm
+# runs first as a canary: a stronger phantom must collapse faster than 0.30 —
+# if it doesn't, the GATE_LAMBDA plumbing is broken and you find out in run 1
+# (also check step-1 metrics: critic/rewards/min must equal exactly -lambda).
+set -uo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=${GATE_ROOT:-$(pwd)/work}
+PY=${VERL_VENV:-$ROOT/venv}/bin/python
+RES=$ROOT/gate_results
+mkdir -p "$RES"
+STEPS=${STEPS:-40}
+
+run() {
+  local mode="$1" lam="$2" tag="$3"
+  local exp="gate_${mode}_lam${tag}" log="$ROOT/${exp}.log"
+  echo "======== $(date) START $exp (lambda=$lam) ========"
+  "$PY" -m ray stop --force >/dev/null 2>&1
+  for p in $(pgrep -u "$(id -un)" -f "verl.trainer.main_ppo"); do kill -9 "$p" 2>/dev/null; done
+  sleep 10
+  env GPU="${GPU:-0}" ADV=grpo LR="${LR:-1e-4}" MAX_STEPS="$STEPS" GUTIL="${GUTIL:-0.3}" \
+      GATE_SHAPED=1 GATE_MODE="$mode" GATE_LAMBDA="$lam" EXP="$exp" \
+      GATE_ROOT="$ROOT" VERL_VENV="${VERL_VENV:-$ROOT/venv}" \
+      bash "$HERE/run_gate_arm.sh" >> "$log" 2>&1
+  {
+    echo "# $exp (lambda=$lam) done $(date)"
+    echo -n "em: "; grep -aoE "acc[^ ]*mean@1:np.float64\([0-9.]+\)" "$log" | sed -E "s/.*\(([0-9.]+)\)/\1/" | cut -c1-6 | paste -sd" "
+    echo -n "gate_last: "; grep -a "\[gate\]" "$log" | tail -1 | grep -aoE "live_frac=[0-9.]+ dropped_rows=[0-9/]+"; echo
+    echo -n "len_last: "; grep -aoE "response_length/mean:[0-9]+" "$log" | tail -1
+  } > "$RES/${exp}.md"
+  echo "ARM_DONE $exp"; cat "$RES/${exp}.md"
+}
+
+run none    0.50 050
+run std     0.50 050
+run outcome 0.50 050
+run none    0.10 010
+run std     0.10 010
+run outcome 0.10 010
+echo "CHAIN_COMPLETE $(date)"

--- a/gsm8k_outcome_gating/run_phantom_chain.sh
+++ b/gsm8k_outcome_gating/run_phantom_chain.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Experiment 3 — reverse phantom (GATE_PHANTOM=long): the length term flips so
+# the LONGEST wrong answer scores best. Probes whether phantom direction
+# matters (it does — see README: the Goodhart asymmetry).
+set -uo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=${GATE_ROOT:-$(pwd)/work}
+PY=${VERL_VENV:-$ROOT/venv}/bin/python
+RES=$ROOT/gate_results
+mkdir -p "$RES"
+STEPS=${STEPS:-40}
+
+run() {
+  local mode="$1" exp="gate_${mode}_ph030" log="$ROOT/gate_${mode}_ph030.log"
+  echo "======== $(date) START $exp (phantom=long lambda=0.30) ========"
+  "$PY" -m ray stop --force >/dev/null 2>&1
+  for p in $(pgrep -u "$(id -un)" -f "verl.trainer.main_ppo"); do kill -9 "$p" 2>/dev/null; done
+  sleep 10
+  env GPU="${GPU:-0}" ADV=grpo LR="${LR:-1e-4}" MAX_STEPS="$STEPS" GUTIL="${GUTIL:-0.3}" \
+      GATE_SHAPED=1 GATE_MODE="$mode" GATE_LAMBDA=0.30 GATE_PHANTOM=long EXP="$exp" \
+      GATE_ROOT="$ROOT" VERL_VENV="${VERL_VENV:-$ROOT/venv}" \
+      bash "$HERE/run_gate_arm.sh" >> "$log" 2>&1
+  {
+    echo "# $exp (phantom=long) done $(date)"
+    echo -n "em: "; grep -aoE "acc[^ ]*mean@1:np.float64\([0-9.]+\)" "$log" | sed -E "s/.*\(([0-9.]+)\)/\1/" | cut -c1-6 | paste -sd" "
+    echo -n "gate_last: "; grep -a "\[gate\]" "$log" | tail -1 | grep -aoE "live_frac=[0-9.]+ dropped_rows=[0-9/]+"; echo
+    echo -n "len_curve: "; grep -aoE "response_length/mean:[0-9]+" "$log" | sed -E "s/.*:([0-9]+)/\1/" | paste -sd" "
+  } > "$RES/${exp}.md"
+  echo "ARM_DONE $exp"; cat "$RES/${exp}.md"
+}
+
+run none
+run std
+run outcome
+echo "CHAIN_COMPLETE $(date)"

--- a/gsm8k_outcome_gating/sitecustomize.py
+++ b/gsm8k_outcome_gating/sitecustomize.py
@@ -1,0 +1,10 @@
+import os as _os
+
+if _os.environ.get("GATE_MODE"):
+    try:
+        import gate_hook as _gh
+
+        _gh.install()
+    except Exception as _e:
+        print("[gate] install failed:", _e, flush=True)
+        raise

--- a/gsm8k_outcome_gating/test_gate_offline.py
+++ b/gsm8k_outcome_gating/test_gate_offline.py
@@ -1,0 +1,100 @@
+"""Offline (no-GPU, no-verl) tests for the gate hook and the shaped reward.
+
+Run from this directory:  python test_gate_offline.py
+Covers the pure-python pieces: group partitioning for both gate modes,
+advantage zeroing, both phantom directions, and lambda scaling.
+"""
+
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from gate_hook import partition, zero_adv  # noqa: E402
+
+
+def reload_reward(**env):
+    for k in ("GATE_LAMBDA", "GATE_PHANTOM"):
+        os.environ.pop(k, None)
+    os.environ.update(env)
+    import gate_shaped_reward
+
+    return importlib.reload(gate_shaped_reward)
+
+
+def test_partition_std_keeps_the_phantom_group():
+    # group "a": all-fail but with reward spread (shaped) -> DAPO's std gate keeps it
+    # group "b": mixed outcomes -> everyone keeps it
+    index = ["a"] * 4 + ["b"] * 4
+    outcome = [0, 0, 0, 0, 1, 0, 1, 0]
+    reward = [-0.1, -0.2, -0.05, -0.3, 1.0, -0.2, 0.9, -0.1]
+    drop, st = partition(index, outcome, reward, "std")
+    assert drop == [], f"std gate should keep std>0 groups, dropped {drop}"
+    assert st["dead_groups"] == 0
+
+
+def test_partition_outcome_drops_the_phantom_group():
+    index = ["a"] * 4 + ["b"] * 4
+    outcome = [0, 0, 0, 0, 1, 0, 1, 0]
+    reward = [-0.1, -0.2, -0.05, -0.3, 1.0, -0.2, 0.9, -0.1]
+    drop, st = partition(index, outcome, reward, "outcome")
+    assert sorted(drop) == [0, 1, 2, 3], f"outcome gate must drop the all-fail group, got {drop}"
+    assert st["dead_groups"] == 1 and st["live_frac"] == 0.5
+
+
+def test_partition_std_drops_degenerate_groups():
+    # identical rewards (post-collapse homogenization) -> std gate finally fires
+    index = ["a"] * 4
+    drop, st = partition(index, [0, 0, 0, 0], [-0.3, -0.3, -0.3, -0.3], "std")
+    assert sorted(drop) == [0, 1, 2, 3] and st["dead_groups"] == 1
+
+
+def test_partition_none_drops_nothing():
+    index = ["a"] * 4
+    drop, st = partition(index, [0, 0, 0, 0], [-0.3, -0.3, -0.3, -0.3], "none")
+    assert drop == [] and st["live_frac"] == 1.0
+
+
+def test_zero_adv_numpy():
+    import numpy as np
+
+    adv = np.ones((4, 3))
+    out = zero_adv(adv, [1, 3])
+    assert out[1].sum() == 0 and out[3].sum() == 0 and out[0].sum() == 3
+
+
+def test_short_phantom_rewards_brevity_in_failures():
+    g = reload_reward()  # defaults: lambda=0.30, phantom=short
+    short_wrong = g.compute_score("openai/gsm8k", "5", "7")["score"]
+    long_wrong = g.compute_score("openai/gsm8k", "x" * 512 + " 5", "7")["score"]
+    assert short_wrong > long_wrong, "short phantom must favor the shortest failure"
+    assert abs(long_wrong - (-0.30)) < 1e-9, "full-length wrong answer scores exactly -lambda"
+
+
+def test_long_phantom_rewards_verbosity_in_failures():
+    g = reload_reward(GATE_PHANTOM="long")
+    short_wrong = g.compute_score("openai/gsm8k", "5", "7")["score"]
+    long_wrong = g.compute_score("openai/gsm8k", "x" * 512 + " 5", "7")["score"]
+    assert long_wrong > short_wrong, "long phantom must favor the longest failure"
+
+
+def test_lambda_scaling():
+    g = reload_reward(GATE_LAMBDA="0.50")
+    assert abs(g.compute_score("openai/gsm8k", "x" * 512 + " 5", "7")["score"] - (-0.50)) < 1e-9
+
+
+def test_outcome_rides_along_and_correctness():
+    g = reload_reward()
+    s = g.compute_score("openai/gsm8k", "so the total is #### 7", "7")
+    assert s["outcome_binary"] == 1 and s["acc"] == 1.0 and s["score"] > 0.5
+    s = g.compute_score("openai/gsm8k", "#### 5", "7")
+    assert s["outcome_binary"] == 0 and s["score"] <= 0.0
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"PASS {fn.__name__}")
+    print(f"\n{len(fns)}/{len(fns)} offline tests passed")


### PR DESCRIPTION
## What

A small, fully-reproducible study of **when group filtering actually matters in GRPO**: `gsm8k_outcome_gating`. Single RTX 5090, Qwen2.5-1.5B-Instruct + LoRA(r=32), GSM8K, ~50 min per 40-step arm, pinned verl commit in `REQUIRED_VERL.txt`.

**TL;DR** — under a shaped reward with a mild length term, an all-fail group has reward std > 0, so a DAPO-style std filter keeps it and GRPO normalizes the shaping noise into full-size "phantom advantages". Result:

| held-out EM @ step 40 (λ=0.30, n=3 replicates) | plain GRPO | DAPO-style std gate | **binary-outcome gate** |
|---|---|---|---|
| shaped GSM8K | 0.102 ± 0.126 💥 | 0.037 ± 0.007 💥 | **0.753 ± 0.006** ✅ |

Same model/data/hyperparameters; all arms start at val@0 ≈ 0.715. Two follow-ups included:

- **Dose-response** over phantom strength λ ∈ {0.10, 0.30, 0.50}: no safe dose for the baselines (λ=0.10 still collapses within 40 steps; λ=0.50 reaches EM 0.000 at mean response length 1 token), the outcome gate is immune at every dose, and the std filter fires only *after* collapse homogenizes outputs (std→0) — it removes the corpse, never the poison.
- **Reverse phantom** (reward the *longest* failure): nobody collapses — the Goodhart asymmetry: a reward-hacking shortcut is lethal only when it destroys task structure (truncation deletes the answer; padding doesn't).

## Design points

- **Advantage-zeroing, not mask-zeroing.** Mask-dropping shrinks the token-mean denominator (loss × 1/live_frac), which Adam's scale invariance largely cancels — we measured that separately under binary rewards, where mask-drop gating is a no-op disguising a learning-rate change. Advantage-zeroing keeps the denominator fixed, so the arms differ only in which groups' gradient is removed.
- The gate groups on the **raw outcome** (`outcome_binary` rides through `reward_extra_info`), never the shaped scalar.
- Complements the `dapo` recipe: dynamic sampling is exactly right under binary rewards; this study maps where its std criterion stops working.

## What's in the box

The exact `gate_hook.py` / `gate_shaped_reward.py` / launch scripts behind every number (paths parameterized), a documented reversible `install_gate.sh` (.pth for Ray-worker injection + a 6-line env-gated branch in the built-in gsm8k reward — `data.custom_reward_function` is bypassed by the async agent-loop reward path at the pinned commit), offline no-GPU tests (9/9), and honest-limitations notes in the README ("independent replicates" vs "seeds", n=1 cells labeled as trends).

CI: ruff v0.14.10 check + format clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
