### PR TITLE
feat(recipe): add Ascend INT8 W8A8 QAT rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The script requires only `bash`, `git`, `awk`, and `pip`/`pip3` on `PATH`. It do
 | gkd/megatron | [`recipe/gkd/megatron/REQUIRED_VERL.txt`](gkd/megatron/REQUIRED_VERL.txt) |
 | gvpo | [`recipe/gvpo/REQUIRED_VERL.txt`](gvpo/REQUIRED_VERL.txt) |
 | infigui-g1 | [`recipe/infigui-g1/REQUIRED_VERL.txt`](infigui-g1/REQUIRED_VERL.txt) |
+| int8_w8a8_qat | [`recipe/int8_w8a8_qat/REQUIRED_VERL.txt`](int8_w8a8_qat/REQUIRED_VERL.txt) |
 | langgraph_agent | [`recipe/langgraph_agent/REQUIRED_VERL.txt`](langgraph_agent/REQUIRED_VERL.txt) |
 | minicpmo | [`recipe/minicpmo/REQUIRED_VERL.txt`](minicpmo/REQUIRED_VERL.txt) |
 | nemo_gym | [`recipe/nemo_gym/REQUIRED_VERL.txt`](nemo_gym/REQUIRED_VERL.txt) |
@@ -101,6 +102,7 @@ The script requires only `bash`, `git`, `awk`, and `pip`/`pip3` on `PATH`. It do
 - [langgraph_agent](https://github.com/verl-project/verl-recipe/tree/main/langgraph_agent): A tiny example to demonstrate multi-turn rollout with [LangGraph ReactAgent](https://langchain-ai.github.io/langgraph/agents/overview/) to solve math expression.
 - [spo](https://github.com/verl-project/verl-recipe/tree/main/spo): [Single-stream Policy Optimization](https://arxiv.org/abs/2509.13232).
 - [partial_rollout](./partial_rollout/): synchronous RL with cross-step rollout interruption + resume to reclaim long-tail GPU bubbles ([APRIL](https://arxiv.org/pdf/2509.18521)-style).
+- [int8_w8a8_qat](./int8_w8a8_qat/): Ascend INT8 W8A8 rollout with FSDP quantization-aware training, backed by [verl-int8-w8a8](https://github.com/sunsunsun98/verl-int8-w8a8/tree/int8-w8a8-v0.7.0).
 - [verl_tinker](./verl_tinker/): Tinker-compatible HTTP server backed by VeRL actors, with separate Tinker cookbook client examples.
 - TBA...
 

--- a/int8_w8a8_qat/README.md
+++ b/int8_w8a8_qat/README.md
@@ -1,0 +1,164 @@
+# Ascend INT8 W8A8 QAT Rollout
+
+## What does this PR do?
+
+This recipe provides an experimental Qwen3-8B GRPO workflow for FSDP actor
+quantization-aware training (QAT) with an Ascend INT8 W8A8 rollout backend.
+Eligible linear layers fake-quantize weights per output channel and activations
+per token during actor training. After each actor update, rollout-ready INT8
+weights and scale metadata are synchronized through veRL's existing vLLM weight
+update path, reducing the precision mismatch between BF16 optimization and W8A8
+sample generation.
+
+## Required `verl` version
+
+This recipe is paired with
+[**verl-int8-w8a8**](https://github.com/sunsunsun98/verl-int8-w8a8/tree/int8-w8a8-v0.7.0), which
+contains the INT8 W8A8 QAT implementation, worker integration, configuration,
+and Ascend rollout support based on official veRL v0.7.0. See
+[`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the exact pinned tag and commit as
+well as copy-pastable installation commands.
+
+## Scope
+
+- Actor training uses FSDP; Megatron is not supported.
+- Rollout uses vLLM with the Ascend ModelSlim quantization backend.
+- `actor_rollout_ref.rollout.quantization=ascend` selects the vLLM backend;
+  `trainer.device=npu` selects the device.
+- `quant_model_description.json` describes the checkpoint's concrete scheme,
+  such as `W8A8_DYNAMIC`, and identifies floating-point fallback modules.
+- Stochastic rounding is enabled by default with `USE_STOCHASTIC=1`.
+- Non-Ascend INT8 rollout kernels have not been validated.
+
+## Environment
+
+Prepare the following before launching:
+
+1. A PyTorch for Ascend environment with compatible vLLM and vLLM Ascend.
+2. A BF16 Qwen3-8B actor checkpoint.
+3. An Ascend W8A8 rollout checkpoint containing
+   `quant_model_description.json` and its required scale/offset metadata.
+4. GSM8K or DAPO-Math training and validation parquet files.
+
+The reference environment used vLLM 0.13.0, vLLM Ascend 0.13.0, and 16 Ascend
+910C NPUs. Treat these as tested reference versions rather than a universal
+compatibility guarantee.
+
+## Installation
+
+From the root of a standalone `verl-recipe` checkout, install the pinned fork:
+
+```bash
+./install_verl.sh --recipe int8_w8a8_qat --show
+./install_verl.sh --recipe int8_w8a8_qat
+```
+
+For an editable checkout instead:
+
+```bash
+./install_verl.sh --recipe int8_w8a8_qat --method git --dest ./verl
+```
+
+The recipe is pinned to the full commit SHA rather than a moving branch. The
+branch and release tag are recorded in `REQUIRED_VERL.txt` for traceability.
+
+## Data Preparation
+
+This recipe supports either GSM8K or DAPO-Math parquet data:
+
+- **GSM8K:** From the pinned `verl-int8-w8a8` checkout, run
+  `python3 examples/data_preprocess/gsm8k.py --local_save_dir ~/data/gsm8k`.
+- **DAPO-Math:** Follow the
+  [DAPO data preparation instructions](../dapo/README.md#quickstart), or run
+  `bash dapo/prepare_dapo_data.sh` from a standalone `verl-recipe` checkout.
+
+Set `TRAIN_FILE` and `VAL_FILE` to the generated files for the dataset selected
+for the experiment.
+
+## Quick Start
+
+The following four path variables are required:
+
+```bash
+export MODEL_PATH=/path/to/Qwen3-8B
+export ROLLOUT_MODEL_PATH=/path/to/Qwen3-8B-W8A8
+export TRAIN_FILE=/path/to/dapo-math-17k.parquet
+export VAL_FILE=/path/to/aime-2024.parquet
+
+bash int8_w8a8_qat/run_qwen3_8b_w8a8.sh
+```
+
+For GSM8K, use its generated parquet files instead:
+
+```bash
+export TRAIN_FILE=~/data/gsm8k/train.parquet
+export VAL_FILE=~/data/gsm8k/test.parquet
+```
+
+When this repository is checked out as `verl/recipe`, use:
+
+```bash
+bash recipe/int8_w8a8_qat/run_qwen3_8b_w8a8.sh
+```
+
+For the 16-NPU reference setup:
+
+```bash
+N_GPUS_PER_NODE=16 \
+CKPT_DIR=/path/to/checkpoints/qwen3-8b-w8a8 \
+bash int8_w8a8_qat/run_qwen3_8b_w8a8.sh
+```
+
+Additional Hydra overrides can be appended to the command:
+
+```bash
+bash int8_w8a8_qat/run_qwen3_8b_w8a8.sh \
+    trainer.total_epochs=2 \
+    trainer.save_freq=100
+```
+
+## Configuration
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `MODEL_PATH` | required | BF16 actor checkpoint used for FSDP training. |
+| `ROLLOUT_MODEL_PATH` | required | Initial Ascend W8A8 rollout checkpoint and quantization metadata. |
+| `TRAIN_FILE` | required | Training parquet path. |
+| `VAL_FILE` | required | Validation parquet path. |
+| `PROJECT_NAME` | `int8-w8a8-qat` | Logger project name. |
+| `EXP_NAME` | `qwen3-8b-int8-w8a8-qat` | Experiment name. |
+| `CKPT_DIR` | `./checkpoints/$EXP_NAME` | Checkpoint output directory. |
+| `N_GPUS_PER_NODE` | `8` | Number of NPUs per node. |
+| `NNODES` | `1` | Number of nodes. |
+| `QAT` | `true` | Enable actor QAT. |
+| `QAT_W_BIT` | `8` | Actor weight fake-quantization bit width; other values are rejected. |
+| `SCALE_SOURCE` | `learned` | Rollout weight-scale source. |
+| `USE_STOCHASTIC` | `1` | Enable deterministic value-hash stochastic rounding. |
+
+### Scale Sources
+
+| `SCALE_SOURCE` | Actor behavior | Rollout export behavior |
+| --- | --- | --- |
+| `learned` or `auto` | Learn per-channel scales with STE and LSQ-style scale gradients. | Export the latest learned scale and offset. |
+| `calibrated` | Initialize fixed scales and offsets from checkpoint safetensors. | Reuse calibrated metadata and quantization range. |
+| `online` | Do not register learned weight-scale parameters. | Recompute per-channel scales from current actor weights. |
+
+The QAT linear layer also learns a SmoothScale reparameterization. Its forward
+path divides activations by the scale and multiplies weights by the same scale,
+then updates a slower EMA reference from the smoothed weights. The EMA term uses
+stop-gradient, coupling forward statistics while decoupling the gradients of
+SmoothScale and WeightScale.
+
+## Validation and Limitations
+
+Before reporting results from a new environment, validate:
+
+- actor loss, reward, KL, and train/rollout log-prob correlation;
+- initial and post-update actor-to-rollout weight synchronization;
+- sensitive-layer floating-point fallback;
+- rollout throughput under the same sampling settings as the BF16 baseline.
+
+Observed rollout speedups depend on model size and workload. The current QAT
+forward/backward path is unfused, so this recipe does not claim universal
+end-to-end training acceleration. Accuracy and performance must be independently
+verified on the target Ascend software stack.

--- a/int8_w8a8_qat/REQUIRED_VERL.txt
+++ b/int8_w8a8_qat/REQUIRED_VERL.txt
@@ -1,0 +1,9 @@
+# Ascend INT8 W8A8 QAT rollout based on verl v0.7.0
+UPSTREAM=https://github.com/sunsunsun98/verl-int8-w8a8.git
+MODE=pinned_tag
+BRANCH=int8-w8a8-v0.7.0
+TAG=int8-w8a8-v0.7.0-r1
+COMMIT=acad76c47e86bd067596156e194e513ad3eb6206
+PIP_INSTALL=pip install verl@git+https://github.com/sunsunsun98/verl-int8-w8a8.git@acad76c47e86bd067596156e194e513ad3eb6206
+GIT_SETUP=git clone https://github.com/sunsunsun98/verl-int8-w8a8.git verl && cd verl && git checkout acad76c47e86bd067596156e194e513ad3eb6206
+NOTES=Experimental Ascend INT8 W8A8 QAT rollout implementation pinned to a custom fork of official verl v0.7.0.

--- a/int8_w8a8_qat/run_qwen3_8b_w8a8.sh
+++ b/int8_w8a8_qat/run_qwen3_8b_w8a8.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+PROJECT_NAME=${PROJECT_NAME:-"int8-w8a8-qat"}
+EXP_NAME=${EXP_NAME:-"qwen3-8b-int8-w8a8-qat"}
+
+MODEL_PATH=${MODEL_PATH:?"Set MODEL_PATH to the BF16 actor checkpoint."}
+ROLLOUT_MODEL_PATH=${ROLLOUT_MODEL_PATH:?"Set ROLLOUT_MODEL_PATH to the Ascend W8A8 checkpoint."}
+TRAIN_FILE=${TRAIN_FILE:?"Set TRAIN_FILE to the training parquet file."}
+VAL_FILE=${VAL_FILE:?"Set VAL_FILE to the validation parquet file."}
+CKPT_DIR=${CKPT_DIR:-"./checkpoints/${EXP_NAME}"}
+
+N_GPUS_PER_NODE=${N_GPUS_PER_NODE:-8}
+NNODES=${NNODES:-1}
+
+# export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
+export HYDRA_FULL_ERROR=1
+export ASCEND_LAUNCH_BLOCKING=0
+export VLLM_USE_V1=1
+export USE_STOCHASTIC=${USE_STOCHASTIC:-1}
+
+QAT=${QAT:-true}
+QAT_W_BIT=${QAT_W_BIT:-8}
+SCALE_SOURCE=${SCALE_SOURCE:-learned}
+
+# Importance Sampling (IS) weights configuration
+ROLLOUT_IS=${ROLLOUT_IS:-null}
+ROLLOUT_IS_THRESHOLD=${ROLLOUT_IS_THRESHOLD:-null}
+ROLLOUT_IS_BATCH_NORMALIZE=${ROLLOUT_IS_BATCH_NORMALIZE:-null}
+
+# Rejection Sampling (RS) configuration
+ROLLOUT_RS=${ROLLOUT_RS:-null}
+ROLLOUT_RS_THRESHOLD=${ROLLOUT_RS_THRESHOLD:-null}
+
+# Algorithm
+TEMPERATURE=${TEMPERATURE:-1.0}
+TOP_P=${TOP_P:-1.0}
+TOP_K=${TOP_K:--1} # 0 for HF rollout, -1 for vLLM rollout
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${VAL_FILE}" \
+    data.train_batch_size=512 \
+    data.max_prompt_length=512 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=True \
+    data.filter_overlong_prompts_workers=32 \
+    data.truncation='left' \
+    data.trust_remote_code=True \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_scheduler_type='constant' \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=3 \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    actor_rollout_ref.actor.optim.clip_grad=1.0 \
+    actor_rollout_ref.actor.grad_clip=1.0 \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.model.use_remove_padding=False \
+    actor_rollout_ref.model.trust_remote_code=True \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=128 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.qat="${QAT}" \
+    actor_rollout_ref.actor.qat_w_bit="${QAT_W_BIT}" \
+    actor_rollout_ref.actor.scale_source="${SCALE_SOURCE}" \
+    actor_rollout_ref.actor.fsdp_config.dtype="bfloat16" \
+    actor_rollout_ref.actor.fsdp_config.model_dtype="bfloat16" \
+    actor_rollout_ref.ref.fsdp_config.dtype="bfloat16" \
+    actor_rollout_ref.ref.fsdp_config.model_dtype="bfloat16" \
+    actor_rollout_ref.rollout.dtype="bfloat16" \
+    actor_rollout_ref.rollout.quantization="ascend" \
+    actor_rollout_ref.rollout.model_path="${ROLLOUT_MODEL_PATH}" \
+    actor_rollout_ref.rollout.load_format="auto" \
+    actor_rollout_ref.rollout.free_cache_engine=True \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.rollout.n=5 \
+    algorithm.rollout_correction.rollout_is="${ROLLOUT_IS}" \
+    algorithm.rollout_correction.rollout_is_threshold="${ROLLOUT_IS_THRESHOLD}" \
+    algorithm.rollout_correction.rollout_is_batch_normalize="${ROLLOUT_IS_BATCH_NORMALIZE}" \
+    algorithm.rollout_correction.rollout_rs="${ROLLOUT_RS}" \
+    algorithm.rollout_correction.rollout_rs_threshold="${ROLLOUT_RS_THRESHOLD}" \
+    actor_rollout_ref.rollout.temperature="${TEMPERATURE}" \
+    actor_rollout_ref.rollout.top_p="${TOP_P}" \
+    actor_rollout_ref.rollout.top_k="${TOP_K}" \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.kl_ctrl.kl_coef=0 \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console","tensorboard"]' \
+    trainer.project_name="${PROJECT_NAME}" \
+    trainer.experiment_name="${EXP_NAME}" \
+    trainer.n_gpus_per_node="${N_GPUS_PER_NODE}" \
+    trainer.default_local_dir="${CKPT_DIR}" \
+    trainer.resume_mode=auto \
+    trainer.nnodes="${NNODES}" \
+    trainer.save_freq=200 \
+    trainer.test_freq=5 \
+    trainer.total_epochs=1 \
+    trainer.device=npu \
+    "$@"


### PR DESCRIPTION
## What does this PR do?

Adds an experimental Ascend INT8 W8A8 rollout recipe with FSDP
quantization-aware training for Qwen3-8B/Qwen3-30B MoE/openPangu-7B GRPO .

The implementation is maintained in:
https://github.com/sunsunsun98/verl-int8-w8a8

The recipe pins the custom veRL v0.7.0-based implementation to tag
`int8-w8a8-v0.7.0-r1` and commit
`acad76c47e86bd067596156e194e513ad3eb6206`.

## Testing

- `bash -n int8_w8a8_qat/run_qwen3_8b_w8a8.sh`
- `bash install_verl.sh --recipe int8_w8a8_qat --show`
- `git diff --check`

## End-to-End Validation

We evaluated the complete INT8 W8A8 RL pipeline with the following
optimization strategies:

- **Stochastic Rounding (SR):** probabilistically rounds a value to one of its
  adjacent quantization levels according to their distances. Compared with
  deterministic nearest rounding, SR reduces systematic rounding bias and
  helps preserve small weight updates during repeated INT8 conversion.
- **Mixed Precision (MP):** applies sensitive-layer precision fallback.
  Quantization-sensitive modules remain in BF16, while other eligible modules
  use INT8 W8A8. This limits quantization error in critical layers while
  retaining most of the low-bit rollout benefits.
- **SmoothScale (SS):** applies a learnable equivalent transformation that
  smooths activation outliers between activations and weights before
  quantization.

The evaluation covers the openPangu-7B dense model and Qwen3-30B MoE model on
GSM8K, followed by openPangu-7B on the more challenging DAPO-Math-17K dataset.
The Pearson coefficient measures the correlation between actor-training and
rollout log probabilities.

### GSM8K (100steps)

| Model | Method | Reward | Pearson (train vs. rollout) |
| --- | --- | ---: | ---: |
| openPangu-7B | BF16 training + BF16 rollout | 0.588 | 0.9994 |
| openPangu-7B | QAT W8 + W8A8 rollout | 0.451 | 0.9723 |
| openPangu-7B | + SR | 0.543 | 0.9613 |
| openPangu-7B | + MP | 0.496 | 0.9854 |
| openPangu-7B | + SR + MP | **0.595** | **0.9862** |
| Qwen3-30B MoE | BF16 training + BF16 rollout | 0.836 | 0.9992 |
| Qwen3-30B MoE | QAT W8 + W8A8 rollout | 0.782 | 0.9903 |
| Qwen3-30B MoE | + SR | 0.816 | 0.9908 |
| Qwen3-30B MoE | + MP | 0.812 | 0.9977 |
| Qwen3-30B MoE | + SR + MP | **0.822** | **0.9978** |

For openPangu-7B, combining SR and MP increases mean reward from 0.451 to
0.595, reaching the BF16 reward level. The train-rollout Pearson coefficient
also improves from 0.9723 to 0.9862.

For Qwen3-30B MoE, SR and MP increase reward from 0.782 to 0.822 and improve
Pearson correlation from 0.9903 to 0.9978. The final reward is within 0.014 of
the BF16 baseline, indicating that the combined strategy remains effective
when scaling from a dense model to a MoE model.

### DAPO-Math-17K (400steps)

| Method | Reward| Pearson (train vs. rollout) |
| --- | ---: | ---: |
| BF16 training + BF16 rollout | 0.309 | 0.9986 |
| QAT W8A8 + W8A8 rollout | 0.252 | 0.9802 |
| + MP | 0.280 | 0.9909 |
| + MP + SS | 0.299 | 0.9872 |
| + SR + MP + SS | **0.305** | **0.9825** |
| QAT W8 + W8A16 rollout + SR + MP + SS | 0.303 | 0.9985 |

Sensitive-layer mixed-precision fallback first improves reward from 0.252 to
0.280. Adding SmoothScale further raises it to 0.299, showing that activation
smoothing helps reduce numerical perturbations during W8A8 rollout.

Combining SR, MP, and SS reaches a reward of 0.305, only 0.004 below the BF16
baseline of 0.309, corresponding to a 1.29% relative gap. The Pearson
coefficient remains above the basic QAT W8A8 rollout baseline.