### PR TITLE
dynamo: NIXL weight-sync backend with multi-node support

### DIFF
--- a/dynamo/README.md
+++ b/dynamo/README.md
@@ -133,6 +133,65 @@ sbatch recipe/dynamo/train_30b_rl_dynamo_kv_metrics.sh     # KV router + metrics
 
 
 
+## NIXL weight sync (checkpoint engine)
+
+By default the trainer pushes weights to the Dynamo workers through verl's
+naive CUDA-IPC path. Setting
+
+```bash
+actor_rollout_ref.rollout.checkpoint_engine.backend=nixl \
+actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=1024
+```
+
+routes refit through verl's `CheckpointEngineManager` instead: the recipe
+spawns one `CheckpointEngineWorker` Ray actor per rollout rank (colocated on
+the paired GPU — CUDA IPC requires same-GPU pairing) and NIXL moves the
+buckets down a trainer → CE₁ → … → CEₙ chain, which crosses nodes at most
+twice regardless of world size.
+
+### Support matrix
+
+| backend | single-node | multi-node |
+|---|---|---|
+| naive | ✅ | ✅ |
+| NIXL  | ✅ | ✅ (2×8 GPU validated) |
+
+### Transport selection (read this before multi-node)
+
+NIXL's default backend is UCX, and UCX picks its transport from `UCX_TLS`.
+The right setting depends on the RDMA fabric:
+
+| fabric | recommendation |
+|---|---|
+| RDMA with native RDMA-read (e.g. InfiniBand / RoCE) | `UCX_TLS=cuda_ipc,cuda_copy,rc,tcp` — `rc` gives native RDMA read at line rate. |
+| RDMA without native RDMA-read (send/recv-only protocols) | UCX can only emulate one-sided reads over send/recv — we measured 0.23 GB/s. Use NIXL's **LIBFABRIC** backend instead: `+actor_rollout_ref.rollout.checkpoint_engine.engine_kwargs.nixl.backends=[LIBFABRIC]`, with your fabric's libfabric provider (≥1.18) on `LD_LIBRARY_PATH`. Same 1 GiB cross-node read: **48.5 GB/s**. |
+
+Cross-node measured on 2 nodes × 8×H100 (RDMA fabric), 3-step GRPO,
+step-3 `update_weights`:
+
+| model | naive | NIXL UCX (tcp / one-sided read emulated over send/recv) | NIXL LIBFABRIC |
+|---|---|---|---|
+| Qwen2.5-0.5B | 3.08 s | 12.2 s / 11.6 s | 3.09 s |
+| Qwen3-8B | 29.7 s | — | **27.1 s** |
+
+At 0.5B the LIBFABRIC path is at parity with naive (the shared per-rank
+engine-consume dominates); at 8B it is ~9% faster. The UCX column shows
+the send/recv emulation ceiling — protocol-level, not tunable.
+
+Two helpers ship with the recipe: `run_nixl_smoke.sh` (a 3-step GRPO
+training smoke parameterised over `NNODES` / `CE_BACKEND`) and
+`nixl_bench.py` (a standalone cross-node bandwidth probe for checking
+what a fabric actually delivers before debugging the training path).
+When running in containers/Kubernetes, give worker pods the fabric's
+RDMA device resource (e.g. `rdma/ib`) and the `IPC_LOCK` capability —
+NIXL needs it to pin memory for RDMA registration, and transfers hang
+without it.
+
+> `engine_kwargs.nixl.backends` requires a small verl-side change (a
+> `backends` kwarg on `NIXLCheckpointEngine`, pending as a separate verl
+> PR); on IB/RoCE
+> fabrics the stock UCX backend needs no verl change.
+
 ## KV-aware routing result
 
 The matched comparison below keeps only Dynamo KV routing with

--- a/dynamo/dynamo_async_server.py
+++ b/dynamo/dynamo_async_server.py
@@ -2157,8 +2157,13 @@ class DynamoReplica(RolloutReplica):
 
         # Now that dynamo.vllm subprocesses are alive on the GPUs identified
         # by self._trainer_worker_infos, spawn matching CheckpointEngineWorker
-        # actors and adopt them as our framework-facing workers.
-        self.workers = self._spawn_rollout_checkpoint_engine_workers()
+        # actors and adopt them as our framework-facing workers. Naive mode
+        # must keep the trainer WorkerDict handles: its refit runs inside
+        # WorkerDict.update_weights, and a CE actor's ServerAdapter would
+        # collide with the WorkerDict adapter on the per-rank IPC socket
+        # (observed as a stuck sender -> 30min NCCL watchdog abort).
+        if self.config.checkpoint_engine.backend != "naive":
+            self.workers = self._spawn_rollout_checkpoint_engine_workers()
 
     def _spawn_rollout_checkpoint_engine_workers(self) -> list[ActorHandle]:
         """Spawn one CheckpointEngineWorker Ray actor per rollout rank.

--- a/dynamo/dynamo_async_server.py
+++ b/dynamo/dynamo_async_server.py
@@ -41,7 +41,9 @@ import ray
 import requests
 from ray.actor import ActorHandle
 
+from verl.checkpoint_engine.base import CheckpointEngineWorker
 from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.device import get_torch_device
 from verl.utils.net_utils import is_valid_ipv6_address
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica
@@ -1788,6 +1790,28 @@ class DynamoHttpServer:
     async def set_global_steps(self, global_steps: int):
         self.global_steps = global_steps
 
+    async def release_kv_cache(self):
+        """Release only kv_cache GPU memory, keeping model weights intact.
+
+        Called by CheckpointEngineManager before backends like NCCL or NIXL
+        rebuild process groups. Dynamo's per-node sidecars route this through
+        the standard reset_prefix_cache path; the engine keeps weights
+        resident (sleep_level=1 from DynamoRollout) so the trainer can write
+        through to live tensors.
+        """
+        if not self._control_endpoints:
+            return
+        await self._engine_method_all("reset_prefix_cache")
+
+    async def resume_kv_cache(self):
+        """Restore kv_cache GPU memory after a weight sync.
+
+        Counterpart to release_kv_cache(). Dynamo never truly releases KV
+        memory (sleep_level=1 keeps weights resident; reset_prefix_cache
+        only drops the cache contents), so there is nothing to resume.
+        """
+        return
+
     async def wait_for_requests_to_drain(self):
         if not self._control_endpoints:
             return
@@ -1836,7 +1860,7 @@ class DynamoHttpServer:
             try:
                 sock.connect(ep)
                 await sock.send(pickle.dumps(req))
-                reply_bytes = await asyncio.wait_for(sock.recv(), timeout=120)
+                reply_bytes = await asyncio.wait_for(sock.recv(), timeout=600)
                 reply = pickle.loads(reply_bytes)
                 if not reply.get("ok"):
                     logger.warning(
@@ -2042,6 +2066,22 @@ class DynamoHttpServer:
 # --------------------------------------------------------------------------- #
 
 
+class _DynamoCheckpointEngineWorker(CheckpointEngineWorker):
+    """CheckpointEngineWorker variant spawned with ``num_gpus=0``.
+
+    The base ``Worker._setup_env_cuda_visible_devices`` reads
+    ``ray.get_runtime_context().get_accelerator_ids()[device_name][0]`` when
+    ``RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1`` — that list is empty
+    for a ``num_gpus=0`` actor, so it IndexErrors. Our spawn helper injects
+    ``CUDA_VISIBLE_DEVICES`` via ``runtime_env`` to pin the actor to the
+    GPU shared with its paired ``dynamo.vllm`` subprocess (CUDA IPC needs
+    same-GPU pairing), so torch sees that single GPU as device 0.
+    """
+
+    def _setup_env_cuda_visible_devices(self):  # type: ignore[override]
+        get_torch_device().set_device(0)
+
+
 class DynamoReplica(RolloutReplica):
     """Manages one logical Dynamo serving replica across N nodes.
 
@@ -2084,8 +2124,28 @@ class DynamoReplica(RolloutReplica):
         return "dynamo_"
 
     async def init_hybrid_worker_pool(self, worker_group):
-        """Initialize Dynamo as worker pool for all rollout GPUs."""
+        """Initialize Dynamo as worker pool for all rollout GPUs.
+
+        The verl CheckpointEngineManager fans weight-sync hooks
+        (update_weights / execute_checkpoint_engine / release_kv_cache /
+        resume_kv_cache) out to per-rollout-rank Ray actors. Dynamo's
+        rollout-side ``engine'' is a subprocess (not a Ray actor) plus a
+        node-level DynamoHttpServer, so we cannot route those hooks through
+        the trainer's borrowed WorkerDict handles — they don't expose the
+        rollout-side methods. We therefore:
+
+        1. Borrow the trainer worker_group only to look up per-GPU placement.
+        2. Spawn dynamo.vllm subprocesses on those GPUs (existing logic).
+        3. Spawn dedicated CheckpointEngineWorker Ray actors (one per
+           rollout rank) colocated on the same GPUs as the subprocess
+           workers via env-injected CUDA_VISIBLE_DEVICES.
+        4. Reassign ``self.workers`` to those CheckpointEngineWorker
+           handles so framework hooks land where the methods actually
+           live.
+        """
         self.rollout_mode = RolloutMode.HYBRID
+        # Hold trainer handles only as a placement lookup; replaced at the
+        # end with dedicated rollout-side actors.
         self.workers = list(worker_group.workers)
 
         assert len(self.workers) % self.world_size == 0, (
@@ -2095,22 +2155,126 @@ class DynamoReplica(RolloutReplica):
         num_logical_replicas = len(self.workers) // self.world_size
         await self._launch_shared_worker_pool(num_logical_replicas=num_logical_replicas)
 
+        # Now that dynamo.vllm subprocesses are alive on the GPUs identified
+        # by self._trainer_worker_infos, spawn matching CheckpointEngineWorker
+        # actors and adopt them as our framework-facing workers.
+        self.workers = self._spawn_rollout_checkpoint_engine_workers()
+
+    def _spawn_rollout_checkpoint_engine_workers(self) -> list[ActorHandle]:
+        """Spawn one CheckpointEngineWorker Ray actor per rollout rank.
+
+        Each actor:
+        - ``num_gpus=0`` — Ray does not see it as competing for the trainer's
+          resource pool slots.
+        - ``CUDA_VISIBLE_DEVICES`` env-injected to the same GPU as the
+          corresponding dynamo subprocess worker, so cupy/torch tensor
+          allocations land where the subprocess can receive them via CUDA IPC.
+        - ``RANK / WORLD_SIZE / LOCAL_RANK / LOCAL_WORLD_SIZE`` env match the
+          trainer rank layout so the actor's ``server_adapter``
+          (recipe.dynamo.dynamo_rollout.ServerAdapter) computes a
+          ``zmq_handle`` that pairs 1:1 with the subprocess worker.
+        - ``MASTER_ADDR / MASTER_PORT`` set so the CheckpointEngineWorker
+          actors form their own torch.distributed cpu:gloo group on
+          ``initialize_global_process_group_ray``. Port chosen to not
+          collide with the trainer's existing distributed init.
+        """
+        worker_infos = self._trainer_worker_infos
+        total_ranks = len(worker_infos)
+        local_world_size = self.gpus_per_node
+        master_port = str(int(os.environ.get("VERL_DYNAMO_CE_MASTER_PORT", "29600")))
+        # CE worker rank 0 lands on the head node; on multi-node setups every
+        # other rank needs head's reachable IP, not 127.0.0.1. Resolve via
+        # ``ray.nodes()`` using the first worker's node_id.
+        master_addr = "127.0.0.1"
+        if worker_infos:
+            head_node_id = worker_infos[0][0]
+            for node in ray.nodes():
+                if node.get("NodeID") == head_node_id:
+                    master_addr = node.get("NodeManagerAddress") or master_addr
+                    break
+
+        # Resolve placement-group ids → PlacementGroup objects (deduped) so
+        # each CE actor can colocate into the same bundle as its paired
+        # trainer worker. ``get_placement_group`` raises if the id is unknown
+        # (e.g. PG cleaned up); falling back to NodeAffinity keeps the actor
+        # on the same node even if PG capture fails.
+        trainer_pg_ids = self._trainer_worker_pg_ids
+        trainer_pg_lookup: dict[str, Any] = {}
+        for pg_id in trainer_pg_ids:
+            if pg_id and pg_id not in trainer_pg_lookup:
+                try:
+                    trainer_pg_lookup[pg_id] = ray.util.get_placement_group(pg_id)
+                except Exception:
+                    trainer_pg_lookup[pg_id] = None
+
+        actors: list[ActorHandle] = []
+        for rank, (node_id, gpu_id) in enumerate(worker_infos):
+            env_vars = {
+                "CUDA_VISIBLE_DEVICES": str(gpu_id),
+                "RANK": str(rank),
+                "WORLD_SIZE": str(total_ranks),
+                "LOCAL_RANK": str(rank % local_world_size),
+                "LOCAL_WORLD_SIZE": str(local_world_size),
+                "RAY_LOCAL_WORLD_SIZE": str(local_world_size),
+                "MASTER_ADDR": master_addr,
+                "MASTER_PORT": master_port,
+                "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+            }
+
+            trainer_pg = trainer_pg_lookup.get(trainer_pg_ids[rank])
+            if trainer_pg is not None:
+                scheduling_strategy = ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy(
+                    placement_group=trainer_pg,
+                    placement_group_bundle_index=rank % local_world_size,
+                    placement_group_capture_child_tasks=False,
+                )
+            else:
+                scheduling_strategy = ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                    node_id=node_id,
+                    soft=False,
+                )
+
+            actor = (
+                ray.remote(num_gpus=0, num_cpus=1)(_DynamoCheckpointEngineWorker)
+                .options(
+                    scheduling_strategy=scheduling_strategy,
+                    runtime_env={"env_vars": env_vars},
+                    name=f"dynamo_ce_worker_{self.replica_rank}_{rank}{self.name_suffix}",
+                )
+                .remote(
+                    rollout_config=self.config,
+                    model_config=self.model_config,
+                    replica_rank=rank // self.world_size,
+                )
+            )
+            actors.append(actor)
+        return actors
+
     async def _launch_shared_worker_pool(self, num_logical_replicas: int):
         """Launch a single frontend backed by all logical replica workers."""
         from verl.utils.device import get_resource_name
 
         tp = self.config.tensor_model_parallel_size
-        worker_infos = await asyncio.gather(
+        worker_infos_raw = await asyncio.gather(
             *[
                 worker.__ray_call__.remote(
                     lambda self: (
                         ray.get_runtime_context().get_node_id(),
                         ray.get_runtime_context().get_accelerator_ids()[get_resource_name()][0],
+                        ray.get_runtime_context().get_placement_group_id(),
                     )
                 )
                 for worker in self.workers
             ]
         )
+        # Strip pg_id from the tuple stored as worker_infos (so existing
+        # downstream consumers see the original 2-tuple shape), and resolve
+        # the per-rank placement_group id to a PlacementGroup object so the
+        # CE worker spawn can colocate into the trainer's bundle.
+        worker_infos = [(node_id, gpu_id) for node_id, gpu_id, _ in worker_infos_raw]
+        pg_ids = [pg_id for _, _, pg_id in worker_infos_raw]
+        self._trainer_worker_infos = worker_infos
+        self._trainer_worker_pg_ids = pg_ids
 
         node_order: list[str] = []
         node_to_workers: dict[str, list[ActorHandle]] = {}

--- a/dynamo/dynamo_rollout.py
+++ b/dynamo/dynamo_rollout.py
@@ -112,6 +112,14 @@ class ServerAdapter(_VllmServerAdapter):
         tag = f"[v4a-4][rank={self.rollout_rank}]"
         print(f"{tag} ENTER update_weights", flush=True)
 
+        # The naive path resumes vLLM inside ``WorkerDict.update_weights``;
+        # the NCCL/NIXL path returns early before that resume runs, so we
+        # wake the engine here (weights + kv_cache) before pushing weights
+        # via CUDA IPC. Without this the IPC handshake finds no GPU buffers
+        # and the next generation request after refit fails on missing KV.
+        if self.config.free_cache_engine and self._ensure_server_handle():
+            await self.server_handle.wake_up.remote(tags=["weights", "kv_cache"])
+
         # Fire RPC (only rank 0 actually fires per parent _execute_method gating).
         future = await self._execute_method(
             "update_weights_from_ipc",

--- a/dynamo/nixl_bench.py
+++ b/dynamo/nixl_bench.py
@@ -11,7 +11,6 @@ import sys
 import time
 
 import torch
-
 from nixl._api import nixl_agent, nixl_agent_config
 
 SIZE = 1 << 30  # 1 GiB

--- a/dynamo/nixl_bench.py
+++ b/dynamo/nixl_bench.py
@@ -1,0 +1,86 @@
+"""Cross-pod NIXL point-to-point bandwidth microbenchmark.
+
+Target (pod B):    python nixl_bench.py target /workspace/bench_meta.bin
+Initiator (pod A): python nixl_bench.py init /workspace/bench_meta.bin
+Metadata file moves A<-B via kubectl cp; target stays alive while the
+initiator times READ transfers of its 1 GiB CUDA buffer.
+"""
+
+import os
+import sys
+import time
+
+import torch
+
+from nixl._api import nixl_agent, nixl_agent_config
+
+SIZE = 1 << 30  # 1 GiB
+ITERS = 5
+
+
+def _make_agent(name: str) -> nixl_agent:
+    backends = os.environ.get("NIXL_BENCH_BACKENDS", "").strip()
+    if backends:
+        cfg = nixl_agent_config(backends=backends.split(","))
+        print(f"[{name}] backends={backends}", flush=True)
+        return nixl_agent(name, cfg)
+    return nixl_agent(name)
+
+
+def target(meta_path: str):
+    agent = _make_agent("bench_target")
+    buf = torch.ones(SIZE, dtype=torch.uint8, device="cuda:0")
+    agent.register_memory(buf)
+    descs = agent.get_xfer_descs(buf)
+    blob_meta = agent.get_agent_metadata()
+    blob_descs = agent.get_serialized_descs(descs)
+    with open(meta_path, "wb") as f:
+        f.write(len(blob_meta).to_bytes(8, "little"))
+        f.write(blob_meta)
+        f.write(blob_descs)
+    print(f"[target] metadata written to {meta_path}; serving. Ctrl-C to stop.", flush=True)
+    while True:
+        # surface inbound notifications so the initiator's completion is visible
+        n = agent.get_new_notifs()
+        if n:
+            print(f"[target] notifs: {list(n.keys())}", flush=True)
+        time.sleep(0.5)
+
+
+def initiator(meta_path: str):
+    agent = _make_agent("bench_init")
+    with open(meta_path, "rb") as f:
+        mlen = int.from_bytes(f.read(8), "little")
+        blob_meta = f.read(mlen)
+        blob_descs = f.read()
+    remote = agent.add_remote_agent(blob_meta)
+    if isinstance(remote, bytes):
+        remote = remote.decode()
+    rdescs = agent.deserialize_descs(blob_descs)
+
+    buf = torch.zeros(SIZE, dtype=torch.uint8, device="cuda:0")
+    agent.register_memory(buf)
+    ldescs = agent.get_xfer_descs(buf)
+
+    # warmup + timed iterations
+    for i in range(ITERS + 1):
+        t0 = time.perf_counter()
+        h = agent.initialize_xfer("READ", ldescs, rdescs, remote, b"bench")
+        state = agent.transfer(h)
+        while state not in ("DONE",):
+            state = agent.check_xfer_state(h)
+            if state == "ERR":
+                print("[init] transfer ERR", flush=True)
+                sys.exit(1)
+        dt = time.perf_counter() - t0
+        agent.release_xfer_handle(h)
+        tag = "warmup" if i == 0 else f"iter{i}"
+        print(f"[init] {tag}: {dt:.3f}s  {SIZE / dt / 1e9:.2f} GB/s", flush=True)
+    ok = bool(buf[:1024].eq(1).all().item()) and bool(buf[-1024:].eq(1).all().item())
+    print(f"[init] data check: {'OK' if ok else 'MISMATCH'}", flush=True)
+
+
+if __name__ == "__main__":
+    mode, path = sys.argv[1], sys.argv[2]
+    os.environ.setdefault("NIXL_LOG_LEVEL", "INFO")
+    (target if mode == "target" else initiator)(path)

--- a/dynamo/run_nixl_smoke.sh
+++ b/dynamo/run_nixl_smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# NIXL refit smoke for the dynamo rollout backend — real training steps so
+# update_weights exercises the CheckpointEngineWorker chain each step.
+# Run from a verl checkout containing this repository at recipe/.
+#   NNODES=1 NGPUS_PER_NODE=8 bash recipe/dynamo/run_nixl_smoke.sh   # single-node
+#   NNODES=2 NGPUS_PER_NODE=8 bash recipe/dynamo/run_nixl_smoke.sh   # multi-node
+set -xuo pipefail
+
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+CE_BACKEND=${CE_BACKEND:-nixl}          # nixl | naive (regression)
+TOTAL_STEPS=${TOTAL_STEPS:-3}
+MODEL_PATH=${MODEL_PATH:-/workspace/models/Qwen2.5-0.5B-Instruct}
+TRAIN_FILE=${TRAIN_FILE:-/workspace/data_dapo/data/dapo-math-17k.parquet}
+TEST_FILE=${TEST_FILE:-/workspace/data_aime/data/aime-2024.parquet}
+BUCKET_MB=${BUCKET_MB:-1024}
+EXP_NAME=${EXP_NAME:-nixl-smoke-${CE_BACKEND}-n${NNODES}}
+
+export VERL_USE_EXTERNAL_MODULES=recipe.dynamo.register
+export HYDRA_FULL_ERROR=1
+
+cd /workspace/verl
+
+python3 -m recipe.dynamo.main_dynamo \
+    algorithm.adv_estimator=grpo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.train_batch_size=8 \
+    data.max_prompt_length=512 \
+    data.max_response_length=512 \
+    data.filter_overlong_prompts=False \
+    data.truncation='left' \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=8 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.rollout.name=dynamo \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.calculate_log_probs=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.max_model_len=1024 \
+    actor_rollout_ref.rollout.n=4 \
+    actor_rollout_ref.rollout.multi_turn.enable=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.checkpoint_engine.backend="${CE_BACKEND}" \
+    actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes="${BUCKET_MB}" \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    ++actor_rollout_ref.rollout.engine_kwargs.dynamo.router_mode=kv \
+    ++actor_rollout_ref.rollout.engine_kwargs.dynamo.thunderagent.enabled=false \
+    trainer.logger='["console"]' \
+    trainer.project_name=verl-dynamo-nixl \
+    trainer.experiment_name="${EXP_NAME}" \
+    trainer.n_gpus_per_node="${NGPUS_PER_NODE}" \
+    trainer.nnodes="${NNODES}" \
+    trainer.val_before_train=False \
+    trainer.test_freq=-1 \
+    trainer.save_freq=-1 \
+    trainer.total_training_steps="${TOTAL_STEPS}" \
+    "$@"
+RC=$?
+echo "TRAIN_RC=${RC}"
+exit ${RC}


### PR DESCRIPTION
# dynamo: NIXL weight-sync backend with multi-node support

## Summary

Adds NIXL checkpoint-engine support to the dynamo recipe's refit path while
keeping the existing naive CUDA-IPC path working. Follow-up to the NIXL work
validated single-node during #110 development; multi-node is now validated
end-to-end on 2 nodes × 8×H100 (RDMA fabric).

Enable with:

```bash
actor_rollout_ref.rollout.checkpoint_engine.backend=nixl \
actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=1024
```

## Support matrix (3-step GRPO smokes)

| backend | single-node (8 GPU) | multi-node (2×8 GPU) |
|---|---|---|
| naive | ✅ | ✅ |
| NIXL  | ✅ | ✅ |

## Key changes

- `_DynamoCheckpointEngineWorker(CheckpointEngineWorker)` spawned with
  `num_gpus=0` + env-injected `CUDA_VISIBLE_DEVICES`; overrides
  `_setup_env_cuda_visible_devices` (base impl IndexErrors for
  `num_gpus=0` actors).
- `DynamoReplica.init_hybrid_worker_pool` spawns one CE actor per rollout
  rank — only for non-naive backends — colocated into the trainer's
  placement-group bundle for the paired GPU (CUDA-IPC handoff requires the
  same physical GPU), then reassigns `self.workers` so
  `CheckpointEngineManager` hooks land on actors that expose them.
  (Spawning them in naive mode wedged the per-rank IPC socket shared with
  the WorkerDict adapter → 30-min NCCL watchdog abort; now guarded.)
- CE gloo group `MASTER_ADDR` resolved via `ray.nodes()` from the head
  trainer worker's node (was 127.0.0.1 — single-node only).
- `DynamoHttpServer.release_kv_cache` / `resume_kv_cache` implemented for
  the manager's NIXL flow (sleep_level=1 semantics).
- `ServerAdapter.update_weights` wakes the engine (weights+kv_cache) at
  entry — the framework path returns before the naive path's resume point.
- `_engine_method_all` ZMQ recv timeout 120→600s (slow init-time sleep on
  large models).
- `dynamo/run_nixl_smoke.sh`: 3-step GRPO training smoke parameterised
  over `NNODES` / `CE_BACKEND` / `MODEL_PATH`.
- `dynamo/nixl_bench.py`: standalone cross-node NIXL bandwidth probe for
  qualifying a fabric before debugging the training path.
- README: checkpoint-engine section with per-fabric transport guidance
  and container requirements (fabric RDMA device resource + `IPC_LOCK`).

## Multi-node transport findings (2 nodes × 8×H100, RDMA fabric)

NIXL's default backend is UCX. On fabrics whose RDMA protocol has no native
RDMA-read (send/recv-only), UCX can only emulate one-sided reads over send/recv — a protocol ceiling, not a tuning issue. NIXL's LIBFABRIC backend
uses the fabric's native RDMA-read + GPUDirect. Standalone cross-node read
of 1 GiB CUDA memory (`dynamo/nixl_bench.py`):

| NIXL backend | bandwidth |
|---|---|
| UCX (one-sided read emulated over send/recv) | 0.23 GB/s |
| LIBFABRIC (native RDMA-read + GPUDirect) | **48.5 GB/s** |

Training refit, step-3 `update_weights`, 3-step GRPO:

| model | naive | NIXL UCX (tcp) | NIXL UCX (one-sided read emulated over send/recv) | NIXL LIBFABRIC |
|---|---|---|---|---|
| Qwen2.5-0.5B | 3.08 s | 12.2 s | 11.6 s | 3.09 s |
| Qwen3-8B | 29.7 s | — | — | **27.1 s (−8.6%)** |

At 0.5B LIBFABRIC is at parity with naive (the shared per-rank
engine-consume dominates); at 8B it is ~9% faster and the gap should grow
with model size. The UCX columns show the send/recv emulation ceiling —
protocol-level, not tunable.

**Picking a transport on your cluster:**

- Fabrics with native RDMA-read (e.g. InfiniBand/RoCE): the stock UCX
  backend needs no extra setup — `UCX_TLS=cuda_ipc,cuda_copy,rc,tcp`.
- Fabrics without native RDMA-read: select the LIBFABRIC backend via
  `+actor_rollout_ref.rollout.checkpoint_engine.engine_kwargs.nixl.backends=[LIBFABRIC]`
  (existing `engine_kwargs.nixl` plumbing; requires a small verl-side
  change — a `backends` kwarg on `NIXLCheckpointEngine`).
