### PR TITLE
[dynamo] FlexKV L2 CPU KV-cache support for the Dynamo rollout backend

### DIFF
--- a/dynamo/README.md
+++ b/dynamo/README.md
@@ -402,3 +402,47 @@ concurrency 384, ThunderAgent reaches **1.94× rollout-phase speedup** and
 **2.40×** and **1.60×**, respectively.
 
 <img src="assets/thunderagent_speedup.png" alt="ThunderAgent speedup over Global LB" width="800">
+
+## FlexKV L2 CPU KV cache (optional)
+
+With `engine_kwargs.dynamo.enable_flexkv=True` every `dynamo.vllm` shard runs a
+[FlexKV](https://github.com/taco-project/FlexKV) server: KV blocks evicted from
+the GPU spill to a CPU (DRAM) tier and are fetched back over PCIe on prefix
+re-hit instead of being recomputed. Combined with the KV-aware router this
+completes the KV-reuse stack for multi-turn agentic rollout. The CPU tier is
+maintained across the sleep/wake weight-sync choreography (`clear_kv_cache`
+forwards `reset_connector` so stale KV is dropped on weight updates).
+
+Validated stack:
+
+| Component | Version |
+|---|---|
+| verl | `main` (tested commit in `REQUIRED_VERL.txt`) |
+| vLLM | https://github.com/vllm-project/vllm/pull/54484 (tested at `4582c0d`) |
+| FlexKV | taco-project/FlexKV `main` ≥ PR #279 (`016c290`), unpatched |
+| ai-dynamo | ≥ 1.4.2 |
+
+Key environment knobs (all defaulted): `FLEXKV_CPU_CACHE_GB`,
+`FLEXKV_CONFIG_PATH`, `FLEXKV_ENABLE_MPS` (default 0 — an MPS daemon started
+inside a shard inherits that shard's `CUDA_VISIBLE_DEVICES` and breaks CUDA
+visibility for later clients), `FLEXKV_INIT_READY_TIMEOUT_S`,
+`VERL_DYNAMO_FE_READY_TIMEOUT` (default 2400 s). Multi-shard nodes are
+isolated automatically (per-shard IPC socket, instance ids, metric-port
+offsets); `FLEXKV_SHARED_CPU_CACHE=1` opts into one shared CPU pool instead.
+
+**Sizing rule:** keep the active working set inside the GPU cache:
+`concurrent_requests_per_engine × mean_context_tokens ≲ 0.7 × gate_tokens`
+(`gate_tokens = kv-cache-memory-bytes / kv_bytes_per_token`). Far above this
+the current FlexKV implementation can enter an allocator-starvation regime
+(in-flight transfer pins defeat vLLM preemption) that stalls the engine;
+fixes are being reported upstream.
+
+Known limitation: models with `tie_word_embeddings=true` (e.g. Qwen ≤ 4B)
+currently fail bucketed IPC weight updates on the PR-54484 loader (tied-alias
+guard); use untied models (Qwen3-8B and larger) for now.
+
+```bash
+# FlexKV L2 acceptance: the standard smoke with FlexKV on
+FLEXKV=1 MODEL_PATH=<untied model> TRAIN_FILE=... TEST_FILE=... \
+  bash dynamo/smoke_dynamo_v1.sh
+```

--- a/dynamo/REQUIRED_VERL.txt
+++ b/dynamo/REQUIRED_VERL.txt
@@ -1,5 +1,6 @@
-# Dynamo ThunderAgent — tested core verl commit
+# Dynamo backend + FlexKV L2 — tested core verl commit (main lineage)
+# Both smokes (backend + FLEXKV=1) pass with the verl tree git-status clean.
 UPSTREAM=https://github.com/verl-project/verl.git
 MODE=pinned_commit
-COMMIT=d82d2777b5dc3e96a8a45168d02660312707ab98
-PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@d82d2777b5dc3e96a8a45168d02660312707ab98
+COMMIT=9c7643648f1e1e109dd30da2da3cf94e1317b229
+PIP_INSTALL=pip install verl@git+https://github.com/verl-project/verl.git@9c7643648f1e1e109dd30da2da3cf94e1317b229

--- a/dynamo/dynamo_async_server.py
+++ b/dynamo/dynamo_async_server.py
@@ -324,6 +324,13 @@ class DynamoHttpServer:
         for key, value in os.environ.items():
             if key.startswith("FLEXKV_"):
                 env[key] = value
+        # MPS off by default (explicit user setting wins): with FlexKV's
+        # default on, the KVManager races to start nvidia-cuda-mps-control,
+        # the daemon inherits this shard's restricted CUDA_VISIBLE_DEVICES,
+        # and EVERY later CUDA client in the container gets routed through
+        # MPS and fails with "No CUDA GPUs are available" on all other GPUs
+        # — including the next run's EngineCore (smokeB run3).
+        env.setdefault("FLEXKV_ENABLE_MPS", "0")
         return env
 
     # ------------------------------------------------------------------ #

--- a/dynamo/dynamo_async_server.py
+++ b/dynamo/dynamo_async_server.py
@@ -294,6 +294,38 @@ class DynamoHttpServer:
         env["DYN_ENABLE_RL"] = "true" if self._enable_rl_mode() else "false"
         return env
 
+    def _enable_flexkv(self) -> bool:
+        """Enable the FlexKV CPU-tier KV cache (KVConnector) in every shard."""
+        return self._dynamo_cfg_bool("enable_flexkv", False)
+
+    def _flexkv_env_vars(self) -> dict[str, str]:
+        """Env forwarded into every dynamo.vllm subprocess when FlexKV is on.
+
+        ``DYNAMO_USE_FLEXKV=1`` activates the KVEventCollector inside FlexKV's
+        vllm_v1_adapter (upstream taco line), which re-publishes FlexKV
+        CPU-cache hits as vLLM ``BlockStored`` events over the ZMQ KV-events
+        channel so the Dynamo KV router can route future requests to workers
+        that already hold those blocks in CPU memory.
+
+        All ``FLEXKV_*`` vars in the trainer environment are forwarded
+        unchanged (config file via FLEXKV_CONFIG_PATH is the primary channel;
+        the explicit list below only documents the common knobs). With the
+        default FlexKV config (instance_num=1, no server_client_mode) each
+        shard runs FlexKV in-process — no external KVServer, no registration
+        protocol.
+
+        Cache-staleness note: no extra reset wiring is needed on this stack —
+        vLLM's pause path (EngineCore.pause_scheduler, clear_cache=True,
+        reset_connector=True default) already resets the FlexKV connector on
+        every abort_all_requests, so the CPU tier cannot serve stale KV
+        across RL weight updates.
+        """
+        env: dict[str, str] = {"DYNAMO_USE_FLEXKV": "1"}
+        for key, value in os.environ.items():
+            if key.startswith("FLEXKV_"):
+                env[key] = value
+        return env
+
     # ------------------------------------------------------------------ #
     # verl interface — addresses
     # ------------------------------------------------------------------ #
@@ -644,6 +676,8 @@ class DynamoHttpServer:
             # the same prefix hashes differently per worker → the router logs
             # "block_hash mismatch" and prefix-cache hits collapse.
             env.setdefault("PYTHONHASHSEED", "0")
+            if self._enable_flexkv():
+                env.update(self._flexkv_env_vars())
 
             cmd = self._build_vllm_cmd(
                 served_model_name,
@@ -855,6 +889,14 @@ class DynamoHttpServer:
             executor_backend = "uni" if tp == 1 else "mp"
         cmd += ["--distributed-executor-backend", str(executor_backend)]
         cmd += ["--kv-events-config", kv_events_config_json]
+        if self._enable_flexkv():
+            # FlexKVConnectorV1 is registered natively in vLLM's
+            # KVConnectorFactory (main + #54484 line). kv_both: the shard both
+            # saves (PUT, incl. offload_aborted_kv) and loads (GET) CPU-tier KV.
+            cmd += [
+                "--kv-transfer-config",
+                '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}',
+            ]
         # Pass through extra args from rollout.engine_kwargs.dynamo.extra_args.
         extra = self._dynamo_cfg().get("extra_args") or []
         if isinstance(extra, list):
@@ -1782,10 +1824,16 @@ class DynamoHttpServer:
         kwargs.setdefault("level", 1)
         await self._engine_method_all("sleep", kwargs=kwargs)
 
-    async def clear_kv_cache(self):
+    async def clear_kv_cache(self, reset_connector: bool = True):
+        # reset_connector is forwarded: with FlexKV (or any KV connector) on,
+        # the CPU tier must drop stale KV too. Without a connector configured
+        # vLLM treats reset_prefix_cache(reset_connector=True) as a no-op
+        # success (scheduler.reset_connector_cache logs and returns True).
         if not self._control_endpoints:
             return
-        await self._engine_method_all("reset_prefix_cache")
+        await self._engine_method_all(
+            "reset_prefix_cache", kwargs={"reset_connector": bool(reset_connector)}
+        )
 
     async def set_global_steps(self, global_steps: int):
         self.global_steps = global_steps

--- a/dynamo/dynamo_async_server.py
+++ b/dynamo/dynamo_async_server.py
@@ -333,6 +333,38 @@ class DynamoHttpServer:
         env.setdefault("FLEXKV_ENABLE_MPS", "0")
         return env
 
+    def _flexkv_shard_env_vars(self, spec_idx: int, worker_cvd: str, num_shards: int) -> dict[str, str]:
+        """Per-shard FlexKV isolation on multi-shard nodes (port of b20472a).
+
+        Private mode (default): every shard runs its own in-process FlexKV
+        stack, so the default ipc socket path (FLEXKV_SERVER_RECV_PORT,
+        ipc:///tmp/flexkv_server) collides across shards — GPU registrations
+        crosstalk and a shard's TransferManager can eat another shard's
+        registration. Suffix the path with the shard's GPU ids. The metrics
+        servers likewise default to fixed ports 8080/8081; offset per shard.
+
+        Shared pool mode (FLEXKV_SHARED_CPU_CACHE=1): all shards join ONE
+        KVServer over one socket — instance_num>1 flips KVManager into
+        server_client_mode (shard 0 spawns the server, others connect), and
+        the cache budget scales by shard count so totals match private mode.
+        NB: server_client_mode re-enters the multi-client registration
+        territory — pair it with FLEXKV_ZMQ_IMMEDIATE=1 /
+        FLEXKV_TRANSLATE_PHYSICAL_DEVICE=1 (the B2 patch gates).
+        """
+        env = self._flexkv_env_vars()
+        base_port = env.get("FLEXKV_SERVER_RECV_PORT", "ipc:///tmp/flexkv_server")
+        if env.get("FLEXKV_SHARED_CPU_CACHE", "0") == "1":
+            env["FLEXKV_INSTANCE_NUM"] = str(num_shards)
+            env["FLEXKV_INSTANCE_ID"] = str(spec_idx)
+            env["FLEXKV_SERVER_RECV_PORT"] = base_port
+            per_shard_gb = float(env.get("FLEXKV_CPU_CACHE_GB", "16"))
+            env["FLEXKV_CPU_CACHE_GB"] = str(int(per_shard_gb * num_shards))
+        else:
+            env["FLEXKV_SERVER_RECV_PORT"] = f"{base_port}_g{worker_cvd.replace(',', '-')}"
+        env["FLEXKV_PY_METRICS_PORT"] = str(int(env.get("FLEXKV_PY_METRICS_PORT", "8080")) + spec_idx * 2)
+        env["FLEXKV_CPP_METRICS_PORT"] = str(int(env.get("FLEXKV_CPP_METRICS_PORT", "8081")) + spec_idx * 2)
+        return env
+
     # ------------------------------------------------------------------ #
     # verl interface — addresses
     # ------------------------------------------------------------------ #
@@ -684,7 +716,7 @@ class DynamoHttpServer:
             # "block_hash mismatch" and prefix-cache hits collapse.
             env.setdefault("PYTHONHASHSEED", "0")
             if self._enable_flexkv():
-                env.update(self._flexkv_env_vars())
+                env.update(self._flexkv_shard_env_vars(spec_idx, worker_cvd, len(worker_specs)))
 
             cmd = self._build_vllm_cmd(
                 served_model_name,

--- a/dynamo/dynamo_thunderagent.py
+++ b/dynamo/dynamo_thunderagent.py
@@ -87,7 +87,9 @@ class DynamoThunderAgentHttpServer(DynamoHttpServer):
             str(self.model_config.local_path),
             "--router-block-size",
             str(self._thunderagent_router_block_size()),
-            "--router-reset-states",
+            # NB: no --router-reset-states — that flag exists only in older
+            # internal builds; dynamo >= 1.4.2 argparse rejects it. Builds
+            # that support it can opt back in via thunderagent.extra_args.
             *self._thunderagent_extra_args(),
         ]
 

--- a/dynamo/dynamo_thunderagent.py
+++ b/dynamo/dynamo_thunderagent.py
@@ -123,10 +123,10 @@ class DynamoThunderAgentHttpServer(DynamoHttpServer):
         return command
 
     def _frontend_router_args(self) -> list[str]:
-        args = super()._frontend_router_args()
-        if self._thunderagent_enabled() and "--router-reset-states" not in args:
-            args.append("--router-reset-states")
-        return args
+        # NB: no --router-reset-states — the flag was removed in dynamo >= 1.4.2
+        # (frontend exits rc=1 on unknown arguments). Re-enable on older dynamo
+        # via thunderagent.extra_args if needed.
+        return super()._frontend_router_args()
 
     def _start_thunderagent(self) -> None:
         if not self._thunderagent_enabled() or self._thunderagent_process is not None:

--- a/dynamo/smoke_dynamo_v1.sh
+++ b/dynamo/smoke_dynamo_v1.sh
@@ -17,6 +17,16 @@ TEST_FILE=${TEST_FILE:-"${RAY_DATA_HOME}/data/aime-2024.parquet"}
 
 export VERL_USE_EXTERNAL_MODULES=recipe.dynamo.register
 
+# FLEXKV=1 turns this same colocated smoke into the FlexKV L2 acceptance run.
+FLEXKV=${FLEXKV:-0}
+flexkv_args=()
+if [ "$FLEXKV" = "1" ]; then
+  export FLEXKV_CPU_CACHE_GB=${FLEXKV_CPU_CACHE_GB:-16} FLEXKV_ENABLE_MPS=${FLEXKV_ENABLE_MPS:-0}
+  flexkv_args=(++actor_rollout_ref.rollout.engine_kwargs.dynamo.enable_flexkv=True)
+fi
+# cold first-load + compile of the model can exceed the 600 s default window
+export VERL_DYNAMO_FE_READY_TIMEOUT=${VERL_DYNAMO_FE_READY_TIMEOUT:-2400}
+
 python3 -m recipe.dynamo.main_dynamo \
     algorithm.adv_estimator=grpo \
     data.train_files="${TRAIN_FILE}" \
@@ -48,6 +58,7 @@ python3 -m recipe.dynamo.main_dynamo \
     trainer.val_only=True \
     trainer.total_training_steps=1 \
     trainer.save_freq=-1 \
+    "${flexkv_args[@]}" \
     "$@"
 
 echo "PASS: Dynamo validation smoke completed"


### PR DESCRIPTION
### What

Adds FlexKV L2 (CPU DRAM) KV-cache support to the existing Dynamo rollout
recipe: GPU-evicted KV blocks spill to a CPU tier and are fetched back over
PCIe on prefix re-hit instead of being recomputed; the tier survives rollout
rounds and weight syncs. Enable with one knob:

```
++actor_rollout_ref.rollout.engine_kwargs.dynamo.enable_flexkv=True
```

verl core and the existing recipe behavior are untouched (FlexKV off = no
change; verl tree stays git-clean through all smokes).

### Versions (tested pins)

| Component | Version |
|---|---|
| verl | `main` @ `9c7643648f1e1e109dd30da2da3cf94e1317b229` (`REQUIRED_VERL.txt`) |
| verl-recipe | this PR, on `main` (`ee3aef1`) |
| vLLM | [vllm#54484](https://github.com/vllm-project/vllm/pull/54484) @ `4582c0d` (provides `FlexKVConnectorV1`, `reset_connector`, `--kv-cache-memory-bytes`) |
| FlexKV | [taco-project/FlexKV](https://github.com/taco-project/FlexKV) `main` ≥ [#279](https://github.com/taco-project/FlexKV/pull/279) (`016c290`), **unpatched** |
| ai-dynamo | 1.4.2 (tested; older versions untested — TA needs `thunderagent.extra_args` re-adding `--router-reset-states` on < 1.4.2) |

### Changes

| File | Change |
|---|---|
| `dynamo_async_server.py` (+91) | FlexKV wiring: per-shard server lifecycle → `FlexKVConnectorV1` (`kv_both`); `FLEXKV_*` env plumbing; per-shard isolation (IPC socket by GPU ids, instance ids, metric-port offsets; optional shared CPU pool); `FLEXKV_ENABLE_MPS=0` default |
| `dynamo_thunderagent.py` (−4/+8) | dynamo ≥ 1.4.2 compat: remove both `--router-reset-states` injectors (flag deleted upstream; frontend exits rc=1 on unknown args) |
| `smoke_dynamo_v1.sh` (+11) | `FLEXKV=1` turns the smoke into the FlexKV acceptance run; frontend-ready window default 2400 s |
| `README.md` (+44) | FlexKV section: pins, knobs, sizing rule, limitations |
| `REQUIRED_VERL.txt` | tested pin → verl main `9c76436` |

### Why — measured benefit

Frozen-replay A/B (identical stacks, FlexKV on/off the only variable; 111
recorded SWE-agent trajectories, median ctx 16k / p90 35k tokens; 4×TP2,
C=64, 32 GiB KV/rank):

| Hardware | FlexKV wall-clock | GPU hit | CPU-tier hit |
|---|---|---|---|
| **8×H20** | **+7.1%** (2260 s vs 2433 s; reproduces the +6.5% of the original deployment) | 77% | 19.3% (1244 H2D, 0 cancelled) |

The CPU tier serves roughly 1 in 5 prefix tokens that would otherwise be
recomputed, with zero errors in both arms.

### Acceptance (all on the pinned stack, 2 GPUs, Qwen3-8B)

| Smoke | Config | Result |
|---|---|---|
| A | **KV-aware router** (`router_mode=kv`), FlexKV off | PASS — carrier + weight-sync choreography, verl tree clean |
| B | **KV-aware router** + `FLEXKV=1` | PASS — per-shard sockets `flexkv_server_g0/g1`, D2H PUTs on both shards, choreography intact |
| C | `thunderagent.enabled=true` (TA owns routing) | PASS — TA router registers on dynamo 1.4.2 (frontend 3/3) |

A/B frontend logs confirm `--router-mode kv`. Note: the smoke script's stock
override is `router_mode=round-robin`; pass
`++actor_rollout_ref.rollout.engine_kwargs.dynamo.router_mode=kv` to exercise
the KV-aware router (as done above).

